### PR TITLE
Improve home page with tabbed auth

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -35,8 +35,3 @@ function logout() {
   </div>
 </template>
 
-<style scoped>
-.nav {
-  user-select: none;
-}
-</style>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -2,28 +2,34 @@
   <div class="page">
     <h2>欢迎来到 DTS</h2>
     <div v-if="!loggedIn" class="auth-box">
-      <el-form @submit.prevent="login">
-        <el-form-item label="用户名">
-          <el-input v-model="loginForm.username" autocomplete="off"></el-input>
-        </el-form-item>
-        <el-form-item label="密码">
-          <el-input type="password" v-model="loginForm.password" autocomplete="off"></el-input>
-        </el-form-item>
-        <el-form-item>
-          <el-button type="primary" @click="login">登录</el-button>
-        </el-form-item>
-      </el-form>
-      <el-form @submit.prevent="register" class="register-form">
-        <el-form-item label="新用户注册">
-          <el-input v-model="registerForm.username" placeholder="用户名"></el-input>
-        </el-form-item>
-        <el-form-item>
-          <el-input type="password" v-model="registerForm.password" placeholder="密码"></el-input>
-        </el-form-item>
-        <el-form-item>
-          <el-button @click="register">注册</el-button>
-        </el-form-item>
-      </el-form>
+      <el-tabs v-model="activeTab" stretch>
+        <el-tab-pane label="登录" name="login">
+          <el-form @submit.prevent="login">
+            <el-form-item label="用户名">
+              <el-input v-model="loginForm.username" autocomplete="off" />
+            </el-form-item>
+            <el-form-item label="密码">
+              <el-input type="password" v-model="loginForm.password" autocomplete="off" />
+            </el-form-item>
+            <el-form-item>
+              <el-button type="primary" @click="login">登录</el-button>
+            </el-form-item>
+          </el-form>
+        </el-tab-pane>
+        <el-tab-pane label="注册" name="register">
+          <el-form @submit.prevent="register">
+            <el-form-item label="用户名">
+              <el-input v-model="registerForm.username" placeholder="用户名" />
+            </el-form-item>
+            <el-form-item label="密码">
+              <el-input type="password" v-model="registerForm.password" placeholder="密码" />
+            </el-form-item>
+            <el-form-item>
+              <el-button @click="register">注册</el-button>
+            </el-form-item>
+          </el-form>
+        </el-tab-pane>
+      </el-tabs>
     </div>
     <div v-else class="welcome">
       <p>已登录：{{ user }}</p>
@@ -38,6 +44,7 @@ import { reactive, ref, computed } from 'vue'
 const loginForm = reactive({ username: '', password: '' })
 const registerForm = reactive({ username: '', password: '' })
 const user = ref(localStorage.getItem('user') || '')
+const activeTab = ref('login')
 
 const loggedIn = computed(() => !!user.value)
 
@@ -64,6 +71,5 @@ function logout() {
 <style scoped>
 .page { padding: 20px; }
 .auth-box { max-width: 400px; margin: 0 auto; }
-.register-form { margin-top: 20px; }
 .welcome { margin-top: 20px; }
 </style>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -63,6 +61,19 @@ button:focus-visible {
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
+  padding-top: 60px;
+}
+
+.nav {
+  user-select: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  z-index: 1000;
+  background-color: #ffffff;
+  border-bottom: 1px solid #dcdfe6;
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
## Summary
- beautify home page login area
- combine login and register forms into Element Plus tabs
- move nav styling to global CSS and fix nav at top

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68707be9537483229f360bcea2096aa3