### PR TITLE
Connect auth forms to backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "dev": "nodemon src/app.js",
+    "start": "node src/app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3000/api

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,0 +1,13 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/api'
+})
+
+export const register = (username, password) =>
+  api.post('/auth/register', { username, password })
+
+export const login = (username, password) =>
+  api.post('/auth/login', { username, password })
+
+export default api

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -40,31 +40,43 @@
 
 <script setup>
 import { reactive, ref, computed } from 'vue'
+import { login as loginApi, register as registerApi } from '../api'
 
 const loginForm = reactive({ username: '', password: '' })
 const registerForm = reactive({ username: '', password: '' })
 const user = ref(localStorage.getItem('user') || '')
 const activeTab = ref('login')
 
-const loggedIn = computed(() => !!user.value)
+const loggedIn = computed(() => !!localStorage.getItem('token'))
 
-function login() {
-  if (loginForm.username) {
-    user.value = loginForm.username
+async function login() {
+  if (!loginForm.username || !loginForm.password) return
+  try {
+    const { data } = await loginApi(loginForm.username, loginForm.password)
+    user.value = data.username
     localStorage.setItem('user', user.value)
+    localStorage.setItem('token', data.token)
+  } catch (e) {
+    alert(e.response?.data?.msg || '登录失败')
   }
 }
 
-function register() {
-  if (registerForm.username) {
-    user.value = registerForm.username
+async function register() {
+  if (!registerForm.username || !registerForm.password) return
+  try {
+    const { data } = await registerApi(registerForm.username, registerForm.password)
+    user.value = data.username
     localStorage.setItem('user', user.value)
+    localStorage.setItem('token', data.token)
+  } catch (e) {
+    alert(e.response?.data?.msg || '注册失败')
   }
 }
 
 function logout() {
   user.value = ''
   localStorage.removeItem('user')
+  localStorage.removeItem('token')
 }
 </script>
 


### PR DESCRIPTION
## Summary
- add API helpers for auth
- wire login/registration forms to backend
- store user token in localStorage
- provide example env file for frontend
- add dev/start scripts in backend

## Testing
- `npm test` (backend) *(fails: no test specified)*
- `npm test` (frontend) *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870825324d0832298009c7294cd754e