### PR TITLE
feat: show game status on home page

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -10,4 +10,8 @@ export const register = (username, password) =>
 export const login = (username, password) =>
   api.post('/auth/login', { username, password })
 
+export const getGameInfo = () => api.get('/game/info')
+export const startGame = () => api.post('/game/start')
+export const stopGame = () => api.post('/game/stop')
+
 export default api


### PR DESCRIPTION
## Summary
- expose new game APIs in frontend
- display current game status on Home page

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6870a32a27d8832284734862ef8eac53