### PR TITLE
Improve home layout and realtime info

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,19 +1,11 @@
 <script setup>
 import { computed } from 'vue'
-import { user, token } from './store/user'
+import { token } from './store/user'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
 
 const loggedIn = computed(() => !!token.value)
-
-function logout() {
-  user.value = ''
-  token.value = ''
-  localStorage.removeItem('user')
-  localStorage.removeItem('token')
-  router.push('/')
-}
 </script>
 
 
@@ -32,7 +24,6 @@ function logout() {
       <el-menu-item index="ranking" @click="router.push('/ranking')">玩家排行</el-menu-item>
       <el-menu-item index="help" @click="router.push('/help')">游戏帮助</el-menu-item>
       <el-menu-item index="admin" @click="router.push('/admin')">游戏管理</el-menu-item>
-      <el-menu-item v-if="loggedIn" index="logout" @click="logout">退出登录</el-menu-item>
     </el-menu>
     <router-view />
   </div>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -1,21 +1,22 @@
 <template>
   <div class="page">
     <h2>欢迎来到 DTS</h2>
-    <div class="game-info">
-      <p>游戏版本：{{ gameInfo.version ?? '未知' }}</p>
-      <p>当前时刻：{{ formatTime(Date.now()) }}</p>
-      <p>状态：{{ gameStatus }}</p>
-      <p>已运行：{{ runtime }}</p>
-      <p>禁区数：{{ gameInfo.areanum ?? '无法获取' }}</p>
-      <p>存活玩家：{{ gameInfo.alivenum ?? '无法获取' }}</p>
-      <p>死亡总数：{{ gameInfo.deathnum ?? '无法获取' }}</p>
-      <el-button size="small" type="primary" @click="manualStart">手动开始游戏</el-button>
-      <el-button size="small" type="danger" @click="manualStop" style="margin-left: 8px">手动关闭游戏</el-button>
-    </div>
-    <div v-if="!loggedIn" class="auth-box">
-      <el-tabs v-model="activeTab" stretch>
-        <el-tab-pane label="登录" name="login">
-          <el-form @submit.prevent="login">
+    <div class="home-container">
+      <div class="game-info">
+        <p>游戏版本：{{ gameInfo.version ?? '未知' }}</p>
+        <p>当前时刻：{{ formatTime(currentTime) }}</p>
+        <p>状态：{{ gameStatus }}</p>
+        <p>已运行：{{ runtime }}</p>
+        <p>禁区数：{{ gameInfo.areanum ?? '无法获取' }}</p>
+        <p>存活玩家：{{ gameInfo.alivenum ?? '无法获取' }}</p>
+        <p>死亡总数：{{ gameInfo.deathnum ?? '无法获取' }}</p>
+        <el-button size="small" type="primary" @click="manualStart">手动开始游戏</el-button>
+        <el-button size="small" type="danger" @click="manualStop" style="margin-left: 8px">手动关闭游戏</el-button>
+      </div>
+      <div v-if="!loggedIn" class="auth-box">
+        <el-tabs v-model="activeTab" stretch>
+          <el-tab-pane label="登录" name="login">
+            <el-form @submit.prevent="login">
             <el-form-item label="用户名">
               <el-input v-model="loginForm.username" autocomplete="off" />
             </el-form-item>
@@ -40,17 +41,18 @@
             </el-form-item>
           </el-form>
         </el-tab-pane>
-      </el-tabs>
-    </div>
-    <div v-else class="welcome">
-      <p>已登录：{{ user }}</p>
-      <el-button type="primary" @click="logout">退出登录</el-button>
+        </el-tabs>
+      </div>
+      <div v-else class="welcome">
+        <p>已登录：{{ user }}</p>
+        <el-button type="primary" @click="logout">退出登录</el-button>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { reactive, ref, computed, onMounted } from 'vue'
+import { reactive, ref, computed, onMounted, onUnmounted } from 'vue'
 import {
   login as loginApi,
   register as registerApi,
@@ -61,6 +63,7 @@ import {
 import { user, token } from '../store/user'
 
 const gameInfo = ref({})
+const currentTime = ref(Date.now())
 
 const loginForm = reactive({ username: '', password: '' })
 const registerForm = reactive({ username: '', password: '' })
@@ -96,7 +99,20 @@ async function fetchGameInfo() {
   }
 }
 
-onMounted(fetchGameInfo)
+let timeTimer
+let infoTimer
+onMounted(() => {
+  fetchGameInfo()
+  timeTimer = setInterval(() => {
+    currentTime.value = Date.now()
+  }, 1000)
+  infoTimer = setInterval(fetchGameInfo, 5000)
+})
+
+onUnmounted(() => {
+  clearInterval(timeTimer)
+  clearInterval(infoTimer)
+})
 
 async function manualStart() {
   try {
@@ -152,7 +168,25 @@ function logout() {
 
 <style scoped>
 .page { padding: 20px; }
-.auth-box { max-width: 400px; margin: 0 auto; }
-.welcome { margin-top: 20px; }
-.game-info { margin-bottom: 20px; }
+.home-container {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+.auth-box {
+  max-width: 400px;
+  margin: 0 auto;
+}
+.welcome {
+  margin-top: 20px;
+}
+.game-info {
+  margin-bottom: 20px;
+}
+@media (max-width: 600px) {
+  .home-container {
+    flex-direction: column;
+  }
+}
 </style>


### PR DESCRIPTION
## Summary
- update home page layout to use a responsive left/right arrangement
- poll game info and time in real time
- remove redundant logout menu item

## Testing
- `npm run lint` (fails: missing script)
- `npm run lint` in backend (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_6870bae5cd788322ba80d03c0b48ffc8