### PR TITLE
Implement JWT refresh token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ cd dts-sample-mongo-vue
     MONGODB_URI=mongodb://localhost:27017/dts
     REDIS_URL=redis://localhost:6379
     JWT_SECRET=your_secret
+    JWT_REFRESH_SECRET=your_refresh_secret
+    JWT_ACCESS_EXPIRES=1h
+    JWT_REFRESH_EXPIRES=7d
     ```
 
 - **启动 MongoDB、Redis 服务**
@@ -208,6 +211,13 @@ npm run lint     # 代码规范检查
 
 首页游戏信息区域提供“手动开始游戏”和“手动关闭游戏”两个按钮，
 分别调用上述 `/api/game/start` 与 `/api/game/stop` 接口，操作成功后自动刷新状态，可用于调试或管理员手动控制游戏进度。
+
+## 认证 API
+
+- **POST `/api/auth/login`**：登录并返回 `token` 与 `refreshToken`
+- **POST `/api/auth/register`**：注册并返回 `token` 与 `refreshToken`
+- **POST `/api/auth/refresh`**：使用 `refreshToken` 获取新的 `token`
+- **POST `/api/auth/logout`**：注销并清除服务器端的 `refreshToken`
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,7 @@
 MONGODB_URI=mongodb://localhost:27017/dts
 REDIS_URL=redis://localhost:6379
 JWT_SECRET=your_secret
+JWT_REFRESH_SECRET=your_refresh_secret
+JWT_ACCESS_EXPIRES=1h
+JWT_REFRESH_EXPIRES=7d
 PORT=3000

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -2,6 +2,18 @@ const User = require('../models/User');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 
+function signAccessToken(id) {
+  return jwt.sign({ id }, process.env.JWT_SECRET, {
+    expiresIn: process.env.JWT_ACCESS_EXPIRES || '1h'
+  });
+}
+
+function signRefreshToken(id) {
+  return jwt.sign({ id }, process.env.JWT_REFRESH_SECRET, {
+    expiresIn: process.env.JWT_REFRESH_EXPIRES || '7d'
+  });
+}
+
 exports.register = async (req, res) => {
   try {
     const { username, password } = req.body;
@@ -14,8 +26,16 @@ exports.register = async (req, res) => {
     }
     const hashed = await bcrypt.hash(password, 10);
     const user = await User.create({ username, password: hashed });
-    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET);
-    res.json({ token, userId: user._id, username: user.username });
+    const token = signAccessToken(user._id);
+    const refreshToken = signRefreshToken(user._id);
+    user.refreshToken = refreshToken;
+    await user.save();
+    res.json({
+      token,
+      refreshToken,
+      userId: user._id,
+      username: user.username
+    });
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: '注册失败' });
@@ -33,10 +53,55 @@ exports.login = async (req, res) => {
     if (!match) {
       return res.status(400).json({ msg: '密码错误' });
     }
-    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET);
-    res.json({ token, userId: user._id, username: user.username });
+    const token = signAccessToken(user._id);
+    const refreshToken = signRefreshToken(user._id);
+    user.refreshToken = refreshToken;
+    await user.save();
+    res.json({
+      token,
+      refreshToken,
+      userId: user._id,
+      username: user.username
+    });
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: '登录失败' });
+  }
+};
+
+exports.refresh = async (req, res) => {
+  try {
+    const { refreshToken } = req.body;
+    if (!refreshToken) {
+      return res.status(400).json({ msg: '缺少刷新令牌' });
+    }
+    const payload = jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET);
+    const user = await User.findById(payload.id);
+    if (!user || user.refreshToken !== refreshToken) {
+      return res.status(401).json({ msg: '刷新令牌无效' });
+    }
+    const token = signAccessToken(user._id);
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(401).json({ msg: '刷新失败' });
+  }
+};
+
+exports.logout = async (req, res) => {
+  try {
+    const { refreshToken } = req.body;
+    if (refreshToken) {
+      try {
+        const payload = jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET);
+        await User.findByIdAndUpdate(payload.id, { refreshToken: '' });
+      } catch (e) {
+        // ignore invalid token
+      }
+    }
+    res.json({ msg: '已退出' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '退出失败' });
   }
 };

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const userSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
   password: { type: String, required: true },
+  refreshToken: { type: String, default: '' },
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -4,5 +4,7 @@ const authController = require('../controllers/authController');
 
 router.post('/register', authController.register);
 router.post('/login', authController.login);
+router.post('/refresh', authController.refresh);
+router.post('/logout', authController.logout);
 
 module.exports = router;

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -10,6 +10,12 @@ export const register = (username, password) =>
 export const login = (username, password) =>
   api.post('/auth/login', { username, password })
 
+export const refresh = refreshToken =>
+  api.post('/auth/refresh', { refreshToken })
+
+export const logout = refreshToken =>
+  api.post('/auth/logout', { refreshToken })
+
 export const getGameInfo = () => api.get('/game/info')
 export const startGame = () => api.post('/game/start')
 export const stopGame = () => api.post('/game/stop')

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -57,8 +57,9 @@ import {
   getGameInfo,
   startGame,
   stopGame,
+  logout as logoutApi,
 } from '../api'
-import { user, token } from '../store/user'
+import { user, token, refreshToken } from '../store/user'
 
 const gameInfo = ref({})
 
@@ -122,8 +123,10 @@ async function login() {
     const { data } = await loginApi(loginForm.username, loginForm.password)
     user.value = data.username
     token.value = data.token
+    refreshToken.value = data.refreshToken
     localStorage.setItem('user', user.value)
     localStorage.setItem('token', token.value)
+    localStorage.setItem('refreshToken', refreshToken.value)
   } catch (e) {
     alert(e.response?.data?.msg || '登录失败')
   }
@@ -135,18 +138,28 @@ async function register() {
     const { data } = await registerApi(registerForm.username, registerForm.password)
     user.value = data.username
     token.value = data.token
+    refreshToken.value = data.refreshToken
     localStorage.setItem('user', user.value)
     localStorage.setItem('token', token.value)
+    localStorage.setItem('refreshToken', refreshToken.value)
   } catch (e) {
     alert(e.response?.data?.msg || '注册失败')
   }
 }
 
-function logout() {
+async function logout() {
+  try {
+    if (refreshToken.value)
+      await logoutApi(refreshToken.value)
+  } catch (e) {
+    // ignore
+  }
   user.value = ''
   token.value = ''
+  refreshToken.value = ''
   localStorage.removeItem('user')
   localStorage.removeItem('token')
+  localStorage.removeItem('refreshToken')
 }
 </script>
 

--- a/frontend/src/store/user.js
+++ b/frontend/src/store/user.js
@@ -2,3 +2,4 @@ import { ref } from 'vue'
 
 export const user = ref(localStorage.getItem('user') || '')
 export const token = ref(localStorage.getItem('token') || '')
+export const refreshToken = ref(localStorage.getItem('refreshToken') || '')

--- a/mogoDB.md/README.md
+++ b/mogoDB.md/README.md
@@ -18,6 +18,17 @@
 
 如果后续还有无法在代码中完成的数据库操作，请在此目录补充说明。
 
+## 刷新令牌字段
+1. 进入 MongoDB shell：`mongo`
+2. 切换数据库：`use dts`
+3. 为现有 `users` 文档添加 `refreshToken` 字段：
+   ```javascript
+   db.users.updateMany(
+     { refreshToken: { $exists: false } },
+     { $set: { refreshToken: '' } }
+   )
+   ```
+
 ## 游戏信息集合
 1. 进入 MongoDB shell：`mongo`
 2. 切换数据库：`use dts`


### PR DESCRIPTION
## Summary
- add refreshToken field to user model
- generate access & refresh tokens on login/register
- add token refresh and logout endpoints
- support refreshToken in frontend store and auth API
- document DB updates and environment variables

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870bafce5dc832291dc2319b58ed622