### PR TITLE
Add sample MongoDB inserts

### DIFF
--- a/mogoDB.md/chats.md
+++ b/mogoDB.md/chats.md
@@ -1,0 +1,13 @@
+# chats 集合示例
+
+`chats` 集合来源于 DTS-SAMPLE 的 `bra_chat` 表。以下示例展示如何插入两条聊天记录。
+
+```javascript
+use dts;
+db.chats.insertMany([
+  { cid: 1, type: 0, time: 0, send: 'Alice', recv: '', msg: '大家好' },
+  { cid: 2, type: 2, time: 5, send: 'Bob', recv: 'Alice', msg: '私聊消息' }
+]);
+```
+
+字段含义与 `backend/src/models/Chat.js` 完全一致。

--- a/mogoDB.md/histories.md
+++ b/mogoDB.md/histories.md
@@ -1,0 +1,32 @@
+# histories 集合示例
+
+该集合对应 DTS-SAMPLE 的 `bra_history` 表。以下示例展示基本的历史记录插入方式：
+
+```javascript
+use dts;
+db.histories.insertMany([
+  {
+    gid: 1,
+    wmode: 0,
+    winner: 'Alice',
+    motto: '勇往直前',
+    gametype: 0,
+    vnum: 16,
+    gtime: 600,
+    gstime: 0,
+    getime: 600,
+    hdmg: 300,
+    hdp: 'Alice',
+    hkill: 3,
+    hkp: 'Bob',
+    winnernum: 1,
+    winnerteamID: '',
+    winnerlist: 'Alice',
+    winnerpdata: '',
+    validlist: 'Alice,Bob',
+    hnews: '游戏结束'
+  }
+]);
+```
+
+字段名与 `backend/src/models/History.js` 保持一致，可根据需要扩充更多记录。

--- a/mogoDB.md/logs.md
+++ b/mogoDB.md/logs.md
@@ -1,0 +1,14 @@
+# logs 集合示例
+
+以下命令演示如何向 `logs` 集合插入示例文档，字段与 `backend/src/models/Log.js` 中定义一致。
+
+```javascript
+// 在 mongo shell 中执行
+use dts;
+db.logs.insertMany([
+  { lid: 1, toid: 0, type: 's', time: 0, log: '游戏开始' },
+  { lid: 2, toid: 1, type: 'b', time: 10, log: '玩家遭遇敌人' }
+]);
+```
+
+这些数据对应 DTS-SAMPLE `bra_log` 表的字段。根据需要可以调整 `lid` 等字段的取值。

--- a/mogoDB.md/mapitems.md
+++ b/mogoDB.md/mapitems.md
@@ -1,0 +1,13 @@
+# mapitems 集合示例
+
+配置文件 `DTS-SAMPLE/include/modules/base/itemmain/config/mapitem.config.php` 中给出了地图道具的原始数据。下面根据该配置转换成 `insertMany` 示例：
+
+```javascript
+use dts;
+db.mapitems.insertMany([
+  { iid: 1, itm: '煤气罐', itmk: 'GBi', itme: 1, itms: '10', itmsk: '', pls: 0 },
+  { iid: 2, itm: '增幅设备', itmk: 'X', itme: 1, itms: '1', itmsk: '', pls: 1 }
+]);
+```
+
+以上字段对齐 `backend/src/models/MapItem.js`，仅为示例可按需修改。

--- a/mogoDB.md/maptraps.md
+++ b/mogoDB.md/maptraps.md
@@ -1,0 +1,13 @@
+# maptraps 集合示例
+
+`trapitem.config.php` 中定义了各类陷阱。以下示例将其中两行转换为插入语句：
+
+```javascript
+use dts;
+db.maptraps.insertMany([
+  { tid: 1, itm: '【最终机枪防线】', itmk: 'TO', itme: 400, itms: '1', itmsk: '1', pls: 0 },
+  { tid: 2, itm: '脉冲防线', itmk: 'TO', itme: 200, itms: '1', itmsk: '', pls: 1 }
+]);
+```
+
+字段与 `backend/src/models/MapTrap.js` 匹配。

--- a/mogoDB.md/newsinfos.md
+++ b/mogoDB.md/newsinfos.md
@@ -1,0 +1,13 @@
+# newsinfos 集合示例
+
+`newsinfos` 集合对应 DTS-SAMPLE 中的 `bra_newsinfo` 表，用于记录游戏进程。示例：
+
+```javascript
+use dts;
+db.newsinfos.insertMany([
+  { nid: 1, time: 1690000000, news: 'gamestart', a: '游戏开始', b: '16名玩家', c: '', d: '', e: '' },
+  { nid: 2, time: 1690000300, news: 'kill', a: 'Alice', b: 'Bob', c: '锐利的刀', d: '', e: '' }
+]);
+```
+
+字段请参考 `backend/src/models/NewsInfo.js`。

--- a/mogoDB.md/roomlisteners.md
+++ b/mogoDB.md/roomlisteners.md
@@ -1,0 +1,13 @@
+# roomlisteners 集合示例
+
+`bra_roomlisteners` 在 DTS-SAMPLE 中记录房间的监听端口。MongoDB 对应集合可这样初始化：
+
+```javascript
+use dts;
+db.roomlisteners.insertMany([
+  { port: 3000, timestamp: 1690000000, roomid: 1, uniqid: 'abc123' },
+  { port: 3001, timestamp: 1690000100, roomid: 2, uniqid: 'def456' }
+]);
+```
+
+字段定义见 `backend/src/models/RoomListener.js`。


### PR DESCRIPTION
## Summary
- document insertion examples for logs, chats, mapitems, maptraps, newsinfos, roomlisteners and histories

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870cdc03ba483229ed35017fd76c65e