### PR TITLE
Add admin field meta UI

### DIFF
--- a/backend/src/fieldsMeta.js
+++ b/backend/src/fieldsMeta.js
@@ -1,0 +1,20 @@
+module.exports = {
+  players: [
+    { name: 'pid', label: '玩家ID', type: 'number' },
+    { name: 'name', label: '昵称', type: 'text' },
+    { name: 'hp', label: '生命值', type: 'number' },
+    { name: 'sp', label: '体力', type: 'number' },
+    { name: 'money', label: '金钱', type: 'number' },
+    { name: 'state', label: '状态', type: 'number' }
+  ],
+  shopitems: [
+    { name: 'sid', label: '物品ID', type: 'number' },
+    { name: 'item', label: '名称', type: 'text' },
+    { name: 'price', label: '价格', type: 'number' },
+    { name: 'area', label: '地区', type: 'number' }
+  ],
+  users: [
+    { name: 'username', label: '用户名', type: 'text' },
+    { name: 'role', label: '角色', type: 'select', options: ['user','admin'] }
+  ]
+}

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const auth = require('../middlewares/auth');
 const checkAdmin = require('../middlewares/admin');
+const fieldsMeta = require('../fieldsMeta');
 
 const models = {
   players: require('../models/Player'),
@@ -23,6 +24,11 @@ router.use(checkAdmin);
 function getModel(name) {
   return models[name];
 }
+
+router.get('/:collection/fieldmeta', (req, res) => {
+  const meta = fieldsMeta[req.params.collection] || [];
+  res.json(meta);
+});
 
 router.get('/:collection', async (req, res) => {
   const Model = getModel(req.params.collection);

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -32,5 +32,6 @@ export const adminList = col => api.get(`/admin/${col}`)
 export const adminCreate = (col, data) => api.post(`/admin/${col}`, data)
 export const adminUpdate = (col, id, data) => api.put(`/admin/${col}/${id}`, data)
 export const adminDelete = (col, id) => api.delete(`/admin/${col}/${id}`)
+export const adminFieldMeta = col => api.get(`/admin/${col}/fieldmeta`)
 
 export default api


### PR DESCRIPTION
## Summary
- provide field metadata via new backend route
- render admin table columns using labels from metadata
- allow per-field editing and item creation with form inputs

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` in backend *(fails: no test specified)*
- `npm run lint` in frontend *(fails: Missing script)*
- `npm test` in frontend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870d33536c883229aabbda7e5b7d779