### PR TITLE
Fix stop game bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ npm run lint     # 代码规范检查
   { "msg": "游戏已开始", "gamestate": "active" }
   ```
 
-- **POST `/api/game/stop`**：将 `gamestate` 设为 `inactive`，成功返回：
+- **POST `/api/game/stop`**：强制结束当前游戏并归档历史，对应返回：
 
   ```json
   { "msg": "游戏已停止", "gamestate": "inactive" }

--- a/backend/src/controllers/gameController.js
+++ b/backend/src/controllers/gameController.js
@@ -1,4 +1,5 @@
 const GameInfo = require('../models/GameInfo');
+const History = require('../models/History');
 
 exports.getInfo = async (req, res) => {
   try {
@@ -54,7 +55,24 @@ exports.stopGame = async (req, res) => {
     if (!info) {
       info = await GameInfo.create({ version: '1.0', gamestate: 0 });
     } else {
+      const now = Math.floor(Date.now() / 1000);
+      // 若游戏正在进行，归档历史记录
+      if (info.gamestate > 10 && info.starttime) {
+        await History.create({
+          gid: info.gamenum,
+          wmode: 6,
+          winner: '',
+          gametype: info.gametype,
+          vnum: info.validnum,
+          gtime: now - info.starttime,
+          gstime: info.starttime,
+          getime: now,
+          hdmg: info.hdamage,
+          hdp: info.hplayer
+        });
+      }
       info.gamestate = 0;
+      info.starttime = 0;
       await info.save();
     }
     res.json({ msg: '游戏已停止', gamestate: info.gamestate });


### PR DESCRIPTION
## Summary
- archive history when stopping a running game
- reset start time after forcing a game to end
- document the API change in README

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870d95698248322ad62749a2130843d