### PR TITLE
实现账号资料编辑功能

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,6 +7,7 @@ require('dotenv').config();
 const authRoutes = require('./routes/auth');
 const gameRoutes = require('./routes/game');
 const adminRoutes = require('./routes/admin');
+const userRoutes = require('./routes/user');
 
 const app = express();
 app.use(cors());
@@ -24,6 +25,7 @@ app.get('/api/ping', (req, res) => res.json({ msg: 'pong' }));
 app.use('/api/auth', authRoutes);
 app.use('/api/game', gameRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/user', userRoutes);
 
 app.listen(process.env.PORT, () => {
   console.log(`后端服务已启动，端口：${process.env.PORT}`);

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,0 +1,35 @@
+const User = require('../models/User');
+const bcrypt = require('bcrypt');
+
+exports.getProfile = (req, res) => {
+  const { username, avatar } = req.user;
+  res.json({ username, avatar });
+};
+
+exports.updateProfile = async (req, res) => {
+  try {
+    const { username, oldPassword, newPassword, avatar } = req.body;
+    const user = req.user;
+    // change username
+    if (username && username !== user.username) {
+      const exists = await User.findOne({ username });
+      if (exists) return res.status(400).json({ msg: '用户名已存在' });
+      user.username = username;
+    }
+    // change password
+    if (newPassword) {
+      if (!oldPassword) return res.status(400).json({ msg: '需要提供旧密码' });
+      const match = await bcrypt.compare(oldPassword, user.password);
+      if (!match) return res.status(400).json({ msg: '旧密码错误' });
+      user.password = await bcrypt.hash(newPassword, 10);
+    }
+    if (avatar !== undefined) {
+      user.avatar = avatar;
+    }
+    await user.save();
+    res.json({ msg: '资料已更新', username: user.username, avatar: user.avatar });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '更新失败' });
+  }
+};

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const userSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
   password: { type: String, required: true },
+  avatar: { type: String, default: '' },
   role: { type: String, default: 'user' },
   refreshToken: { type: String, default: '' },
   createdAt: { type: Date, default: Date.now }

--- a/backend/src/routes/user.js
+++ b/backend/src/routes/user.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const userController = require('../controllers/userController');
+const auth = require('../middlewares/auth');
+
+router.use(auth);
+router.get('/profile', userController.getProfile);
+router.put('/profile', userController.updateProfile);
+
+module.exports = router;

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -39,4 +39,7 @@ export const adminUpdate = (col, id, data) => api.put(`/admin/${col}/${id}`, dat
 export const adminDelete = (col, id) => api.delete(`/admin/${col}/${id}`)
 export const adminFieldMeta = col => api.get(`/admin/${col}/fieldmeta`)
 
+export const getProfile = () => api.get('/user/profile')
+export const updateProfile = data => api.put('/user/profile', data)
+
 export default api

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -1,10 +1,50 @@
 <template>
   <div class="page">
-    <h2>Profile</h2>
+    <el-form :model="form" label-width="80px">
+      <el-form-item label="用户名">
+        <el-input v-model="form.username" />
+      </el-form-item>
+      <el-form-item label="旧密码">
+        <el-input v-model="form.oldPassword" type="password" />
+      </el-form-item>
+      <el-form-item label="新密码">
+        <el-input v-model="form.newPassword" type="password" />
+      </el-form-item>
+      <el-form-item label="头像">
+        <el-input v-model="form.avatar" placeholder="暂未开放上传" />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" @click="save">保存</el-button>
+      </el-form-item>
+    </el-form>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue'
+import { getProfile, updateProfile } from '../api'
+import { user } from '../store/user'
+
+const form = ref({
+  username: '',
+  oldPassword: '',
+  newPassword: '',
+  avatar: ''
+})
+
+onMounted(async () => {
+  const res = await getProfile()
+  form.value.username = res.data.username
+  form.value.avatar = res.data.avatar
+})
+
+const save = async () => {
+  await updateProfile(form.value)
+  user.value = form.value.username
+  localStorage.setItem('user', form.value.username)
+  form.value.oldPassword = ''
+  form.value.newPassword = ''
+}
 </script>
 
 <style scoped>

--- a/mogoDB.md/README.md
+++ b/mogoDB.md/README.md
@@ -40,6 +40,18 @@
    )
    ```
 
+## 头像字段
+新增 `avatar` 字段用于存储头像地址，如已有文档需执行：
+1. 进入 MongoDB shell：`mongo`
+2. 切换数据库：`use dts`
+3. 初始化字段：
+   ```javascript
+   db.users.updateMany(
+     { avatar: { $exists: false } },
+     { $set: { avatar: '' } }
+   )
+   ```
+
 ## 游戏信息集合
 1. 进入 MongoDB shell：`mongo`
 2. 切换数据库：`use dts`


### PR DESCRIPTION
## Summary
- 新增 `avatar` 字段到 `User` 模型
- 新增用户资料控制器和路由，可获取并修改用户名、密码和头像
- 前端 `Profile` 页面实现资料修改表单
- 提供对应的 API 调用
- 在 `mogoDB.md/README.md` 中说明头像字段的数据库操作

## Testing
- `npm test` *(backend)* – fails: Error: no test specified
- `npm test` *(frontend)* – fails: missing script

------
https://chatgpt.com/codex/tasks/task_e_68748b2cef4c8322837175bf71fb5be7