### PR TITLE
Implement player state persistence and map admin view

### DIFF
--- a/backend/src/fieldsMeta.js
+++ b/backend/src/fieldsMeta.js
@@ -4,6 +4,7 @@ module.exports = {
     { name: 'name', label: '昵称', type: 'text' },
     { name: 'hp', label: '生命值', type: 'number' },
     { name: 'sp', label: '体力', type: 'number' },
+    { name: 'pls', label: '所在区域', type: 'number' },
     { name: 'money', label: '金钱', type: 'number' },
     { name: 'state', label: '状态', type: 'number' }
   ],
@@ -87,6 +88,10 @@ gameinfos: [
   { name: 'roomvars', label: '房间变量', type: 'text' },
   { name: 'gamevars', label: '游戏变量', type: 'text' }
 ],
+  maps: [
+    { name: 'pls', label: '区域', type: 'number' },
+    { name: 'players', label: '玩家列表', type: 'text' }
+  ],
 
 
 

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -21,6 +21,27 @@ const models = {
 router.use(auth);
 router.use(checkAdmin);
 
+router.get('/maps/fieldmeta', (req, res) => {
+  const meta = fieldsMeta['maps'] || [];
+  res.json(meta);
+});
+
+router.get('/maps', async (req, res) => {
+  try {
+    const players = await models.players.find({}, 'pid name pls');
+    const grouped = {};
+    players.forEach(p => {
+      if (!grouped[p.pls]) grouped[p.pls] = [];
+      grouped[p.pls].push({ pid: p.pid, name: p.name });
+    });
+    const result = Object.keys(grouped).map(pls => ({ pls: Number(pls), players: grouped[pls] }));
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '获取失败' });
+  }
+});
+
 function getModel(name) {
   return models[name];
 }

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -38,5 +38,6 @@ export const adminCreate = (col, data) => api.post(`/admin/${col}`, data)
 export const adminUpdate = (col, id, data) => api.put(`/admin/${col}/${id}`, data)
 export const adminDelete = (col, id) => api.delete(`/admin/${col}/${id}`)
 export const adminFieldMeta = col => api.get(`/admin/${col}/fieldmeta`)
+export const adminMaps = () => api.get('/admin/maps')
 
 export default api

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -4,16 +4,16 @@
     <el-select v-model="collection" placeholder="选择集合" style="width: 200px">
       <el-option v-for="c in collections" :key="c.value" :label="c.label" :value="c.value" />
     </el-select>
-    <el-button type="primary" size="small" @click="openCreate" style="margin-left:10px">新建</el-button>
+    <el-button v-if="!isMaps" type="primary" size="small" @click="openCreate" style="margin-left:10px">新建</el-button>
     <el-table :data="items" style="margin-top: 20px" row-key="_id">
       <el-table-column prop="_id" label="ID" width="230" />
       <el-table-column v-for="f in fieldMeta" :key="f.name" :prop="f.name" :label="f.label">
         <template #default="{ row }">
           <span>{{ row[f.name] }}</span>
-          <el-button size="small" text @click="openFieldEdit(row, f)">编辑</el-button>
+          <el-button v-if="!isMaps" size="small" text @click="openFieldEdit(row, f)">编辑</el-button>
         </template>
       </el-table-column>
-      <el-table-column label="操作" width="120">
+      <el-table-column v-if="!isMaps" label="操作" width="120">
         <template #default="{ row }">
           <el-button size="small" type="danger" @click="remove(row)">删除</el-button>
         </template>
@@ -53,13 +53,14 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import {
   adminList,
   adminCreate,
   adminUpdate,
   adminDelete,
-  adminFieldMeta
+  adminFieldMeta,
+  adminMaps
 } from '../api'
 
 const collections = [
@@ -73,7 +74,8 @@ const collections = [
   { label: '房间监听', value: 'roomlisteners' },
   { label: '历史记录', value: 'histories' },
   { label: '游戏信息', value: 'gameinfos' },
-  { label: '用户', value: 'users' }
+  { label: '用户', value: 'users' },
+  { label: '地图', value: 'maps' }
 ]
 
 const collection = ref('')
@@ -87,6 +89,7 @@ const editValue = ref('')
 
 const createDialogVisible = ref(false)
 const createData = ref({})
+const isMaps = computed(() => collection.value === 'maps')
 
 watch(collection, () => {
   fetchFieldMeta()
@@ -106,8 +109,17 @@ async function fetchFieldMeta() {
 async function fetchItems() {
   if (!collection.value) return
   try {
-    const { data } = await adminList(collection.value)
-    items.value = data
+    if (collection.value === 'maps') {
+      const { data } = await adminMaps()
+      items.value = data.map(d => ({
+        _id: d.pls,
+        pls: d.pls,
+        players: d.players.map(p => `${p.name}(${p.pid})`).join(', ')
+      }))
+    } else {
+      const { data } = await adminList(collection.value)
+      items.value = data
+    }
   } catch (e) {
     alert(e.response?.data?.msg || '加载失败')
   }

--- a/frontend/src/pages/EnterGame.vue
+++ b/frontend/src/pages/EnterGame.vue
@@ -6,8 +6,9 @@
 </template>
 
 <script setup>
-import { enterGame } from '../api'
+import { enterGame, getStatus } from '../api'
 import { playerId } from '../store/user'
+import { playerInfo } from '../store/player'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -17,6 +18,8 @@ async function start() {
     const { data } = await enterGame()
     playerId.value = data.pid
     localStorage.setItem('playerId', data.pid)
+    const status = await getStatus(data.pid)
+    playerInfo.value = status.data
     router.push('/map')
   } catch (e) {
     alert(e.response?.data?.msg || '进入失败')

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="page">
     <h2>地图</h2>
+    <el-descriptions v-if="info" border :column="2" style="margin-bottom:8px">
+      <el-descriptions-item label="位置">{{ places[info.pls] }}</el-descriptions-item>
+      <el-descriptions-item label="生命">{{ info.hp }}/{{ info.mhp }}</el-descriptions-item>
+      <el-descriptions-item label="体力">{{ info.sp }}/{{ info.msp }}</el-descriptions-item>
+    </el-descriptions>
     <el-select v-model="target" placeholder="选择地点" style="width: 200px">
       <el-option v-for="(n,i) in places" :key="i" :label="n" :value="i" />
     </el-select>
@@ -11,19 +16,37 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { move, search } from '../api'
+import { ref, onMounted } from 'vue'
+import { move, search, getStatus } from '../api'
 import { playerId } from '../store/user'
+import { playerInfo as info } from '../store/player'
 import places from '../utils/places'
 
 const target = ref(0)
 const log = ref('')
+
+async function fetchStatus() {
+  if (!playerId.value) return
+  try {
+    const { data } = await getStatus(playerId.value)
+    info.value = data
+    target.value = data.pls
+  } catch (e) {
+    info.value = null
+  }
+}
+
+onMounted(() => {
+  if (info.value) target.value = info.value.pls
+  else fetchStatus()
+})
 
 async function doMove() {
   if (!playerId.value) return
   try {
     const { data } = await move(playerId.value, target.value)
     log.value = data.msg
+    info.value = data.player
   } catch (e) {
     alert(e.response?.data?.msg || '移动失败')
   }
@@ -34,6 +57,7 @@ async function doSearch() {
   try {
     const { data } = await search(playerId.value)
     log.value = data.log
+    info.value = data.player
   } catch (e) {
     alert(e.response?.data?.msg || '搜索失败')
   }

--- a/frontend/src/store/player.js
+++ b/frontend/src/store/player.js
@@ -1,0 +1,11 @@
+import { ref, watch } from 'vue'
+
+export const playerInfo = ref(JSON.parse(localStorage.getItem('playerInfo') || 'null'))
+
+watch(playerInfo, val => {
+  if (val) {
+    localStorage.setItem('playerInfo', JSON.stringify(val))
+  } else {
+    localStorage.removeItem('playerInfo')
+  }
+}, { deep: true })


### PR DESCRIPTION
## Summary
- persist player info in localStorage
- fetch and display player status on map page
- preload status after entering the game
- expose new admin maps endpoint and field meta
- show current location in admin player list and new map list

## Testing
- `npm test` (backend, expected failure: no test specified)
- `npm test` (frontend, expected failure: missing script)

------
https://chatgpt.com/codex/tasks/task_e_68748a93e8d08322b0a1f0b41500e4eb