### PR TITLE
Fix repeated player creation

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -1,21 +1,37 @@
 const Player = require('../models/Player');
 const MapItem = require('../models/MapItem');
 const MapTrap = require('../models/MapTrap');
+const GameInfo = require('../models/GameInfo');
 const { plsinfo } = require('../config/map');
 
 exports.enter = async (req, res) => {
   try {
-    const last = await Player.findOne().sort({ pid: -1 });
-    const pid = last ? last.pid + 1 : 1;
-    const player = await Player.create({
-      pid,
-      name: req.user.username,
-      pls: 0,
-      hp: 100,
-      mhp: 100,
-      sp: 100,
-      msp: 100
-    });
+    const user = req.user;
+    const info = await GameInfo.findOne();
+    const gid = info ? info.gamenum : 0;
+
+    let player = null;
+    if (user.lastgame === gid && user.lastpid) {
+      player = await Player.findOne({ pid: user.lastpid });
+    }
+
+    if (!player) {
+      const last = await Player.findOne().sort({ pid: -1 });
+      const pid = last ? last.pid + 1 : 1;
+      player = await Player.create({
+        pid,
+        name: user.username,
+        pls: 0,
+        hp: 100,
+        mhp: 100,
+        sp: 100,
+        msp: 100
+      });
+      user.lastgame = gid;
+      user.lastpid = pid;
+      await user.save();
+    }
+
     res.json({ pid: player.pid, pls: player.pls });
   } catch (err) {
     console.error(err);

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -6,6 +6,8 @@ const userSchema = new mongoose.Schema({
   avatar: { type: String, default: '' },
   role: { type: String, default: 'user' },
   refreshToken: { type: String, default: '' },
+  lastgame: { type: Number, default: 0 },
+  lastpid: { type: Number, default: 0 },
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/mogoDB.md/README.md
+++ b/mogoDB.md/README.md
@@ -120,6 +120,22 @@
 2. 执行以下命令导入初始数据：
    ```bash
    mongoimport --db dts --collection gameinfos --file ../data/gameinfo.json --jsonArray
-   mongoimport --db dts --collection shopitems --file ../data/shopitems.json --jsonArray
-   ```
+ mongoimport --db dts --collection shopitems --file ../data/shopitems.json --jsonArray
+  ```
 3. 导入完成后即可获得与原作一致的基础记录与商店物品。
+
+## 单局玩家绑定字段
+为用户集合新增 `lastgame` 与 `lastpid` 字段以记录当前游戏局及绑定的玩家：
+1. 进入 MongoDB shell：`mongo`
+2. 切换数据库：`use dts`
+3. 执行以下更新：
+   ```javascript
+   db.users.updateMany(
+     { lastgame: { $exists: false } },
+     { $set: { lastgame: 0 } }
+   )
+   db.users.updateMany(
+     { lastpid: { $exists: false } },
+     { $set: { lastpid: 0 } }
+   )
+   ```


### PR DESCRIPTION
## Summary
- associate logged in user with one Player per game round
- check existing player on enter
- document DB updates for new fields

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68748f3625bc8322903660ad3eb3b1cf