### PR TITLE
Fix game entry routing

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,8 +16,7 @@ const loggedIn = computed(() => !!token.value)
       <el-menu-item index="mail" @click="router.push('/mail')">站内邮件</el-menu-item>
       <el-menu-item index="profile" @click="router.push('/profile')">帐号资料</el-menu-item>
       <el-menu-item v-if="!loggedIn" index="game" @click="router.push('/')">进入游戏</el-menu-item>
-      <el-menu-item v-else index="game" @click="router.push('/game')">进入游戏</el-menu-item>
-      <el-menu-item index="map" @click="router.push('/map')">战场地图</el-menu-item>
+      <el-menu-item v-else index="game" @click="router.push('/start')">进入游戏</el-menu-item>
       <el-menu-item index="status" @click="router.push('/status')">进行状况</el-menu-item>
       <el-menu-item index="alive" @click="router.push('/alive')">当前幸存</el-menu-item>
       <el-menu-item index="victory" @click="router.push('/victory')">历史优胜</el-menu-item>

--- a/frontend/src/pages/Game.vue
+++ b/frontend/src/pages/Game.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="page">
+    <h2>游戏界面</h2>
+    <MapModule />
+  </div>
+</template>
+
+<script setup>
+import MapModule from './Map.vue'
+</script>
+
+<style scoped>
+.page { padding: 20px; }
+</style>

--- a/frontend/src/pages/Start.vue
+++ b/frontend/src/pages/Start.vue
@@ -6,10 +6,11 @@
 </template>
 
 <script setup>
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { enterGame, getStatus } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo } from '../store/player'
-import { useRouter } from 'vue-router'
 
 const router = useRouter()
 
@@ -20,11 +21,22 @@ async function start() {
     localStorage.setItem('playerId', data.pid)
     const status = await getStatus(data.pid)
     playerInfo.value = status.data
-    router.push('/map')
+    router.push('/game')
   } catch (e) {
     alert(e.response?.data?.msg || '进入失败')
   }
 }
+
+onMounted(async () => {
+  if (!playerId.value) return
+  try {
+    const { data } = await getStatus(playerId.value)
+    playerInfo.value = data
+    router.replace('/game')
+  } catch (e) {
+    // ignore if player not found
+  }
+})
 </script>
 
 <style scoped>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,8 +2,8 @@ import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../pages/Home.vue'
 import Mail from '../pages/Mail.vue'
 import Profile from '../pages/Profile.vue'
-import EnterGame from '../pages/EnterGame.vue'
-import Map from '../pages/Map.vue'
+import Start from '../pages/Start.vue'
+import Game from '../pages/Game.vue'
 import Status from '../pages/Status.vue'
 import Alive from '../pages/Alive.vue'
 import Victory from '../pages/Victory.vue'
@@ -15,8 +15,8 @@ const routes = [
   { path: '/', name: 'Home', component: Home },
   { path: '/mail', name: 'Mail', component: Mail },
   { path: '/profile', name: 'Profile', component: Profile },
-  { path: '/game', name: 'EnterGame', component: EnterGame },
-  { path: '/map', name: 'Map', component: Map },
+  { path: '/start', name: 'Start', component: Start },
+  { path: '/game', name: 'Game', component: Game },
   { path: '/status', name: 'Status', component: Status },
   { path: '/alive', name: 'Alive', component: Alive },
   { path: '/victory', name: 'Victory', component: Victory },


### PR DESCRIPTION
## Summary
- refactor front-end routes for start/game pages
- embed map within new `Game.vue`
- redirect to start page when clicking "进入游戏"

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: package.json not found)*
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_687493637e308322a37ce0ef5cc0fcc1