### PR TITLE
实现进行状况角色绑定展示

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -115,3 +115,23 @@ exports.status = async (req, res) => {
     res.status(500).json({ msg: '获取状态失败' });
   }
 };
+
+exports.list = async (req, res) => {
+  try {
+    const info = await GameInfo.findOne();
+    const gid = info ? info.gamenum : 0;
+    const users = await require('../models/User').find({ lastgame: gid, lastpid: { $gt: 0 } }, 'username lastpid');
+    const pids = users.map(u => u.lastpid);
+    const players = await Player.find({ pid: { $in: pids } }, 'pid name hp');
+    const map = {};
+    players.forEach(p => { map[p.pid] = p; });
+    const list = users.map(u => {
+      const p = map[u.lastpid] || {};
+      return { pid: u.lastpid, name: p.name || '', username: u.username, alive: p.hp > 0 };
+    });
+    res.json(list);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '获取玩家列表失败' });
+  }
+};

--- a/backend/src/routes/game.js
+++ b/backend/src/routes/game.js
@@ -12,5 +12,6 @@ router.post('/enter', auth, playerController.enter);
 router.post('/move', auth, playerController.move);
 router.post('/search', auth, playerController.search);
 router.get('/status', auth, playerController.status);
+router.get('/players', auth, playerController.list);
 
 module.exports = router;

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -32,6 +32,7 @@ export const enterGame = () => api.post('/game/enter')
 export const move = (pid, pls) => api.post('/game/move', { pid, pls })
 export const search = pid => api.post('/game/search', { pid })
 export const getStatus = pid => api.get('/game/status', { params: { pid } })
+export const getPlayers = () => api.get('/game/players')
 
 export const adminList = col => api.get(`/admin/${col}`)
 export const adminCreate = (col, data) => api.post(`/admin/${col}`, data)

--- a/frontend/src/pages/Alive.vue
+++ b/frontend/src/pages/Alive.vue
@@ -1,10 +1,34 @@
 <template>
   <div class="page">
-    <h2>Alive</h2>
+    <h2>进行状况</h2>
+    <el-table :data="players" style="width: 100%; margin-top:10px">
+      <el-table-column prop="name" label="角色名" />
+      <el-table-column prop="username" label="用户" />
+      <el-table-column prop="alive" label="存活">
+        <template #default="scope">
+          <span>{{ scope.row.alive ? '是' : '否' }}</span>
+        </template>
+      </el-table-column>
+    </el-table>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue'
+import { getPlayers } from '../api'
+
+const players = ref([])
+
+async function fetch() {
+  try {
+    const { data } = await getPlayers()
+    players.value = data
+  } catch (e) {
+    players.value = []
+  }
+}
+
+onMounted(fetch)
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- 新增 `/game/players` 接口，返回当前局各玩家与其绑定用户信息
- 前端 `Alive` 页面展示角色、所属用户及存活状态
- 更新前端 API 封装以调用新接口

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_687494609d3c8322b76868f502531f61