### PR TITLE
Check gamestate before player actions

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -4,11 +4,16 @@ const MapTrap = require('../models/MapTrap');
 const GameInfo = require('../models/GameInfo');
 const { plsinfo } = require('../config/map');
 
+const START_THRESHOLD = 20;
+
 exports.enter = async (req, res) => {
   try {
     const user = req.user;
     const info = await GameInfo.findOne();
-    const gid = info ? info.gamenum : 0;
+    if (!info || info.gamestate < START_THRESHOLD) {
+      return res.status(400).json({ msg: '游戏未开始' });
+    }
+    const gid = info.gamenum;
 
     let player = null;
     if (user.lastgame === gid && user.lastpid) {
@@ -43,6 +48,10 @@ exports.enter = async (req, res) => {
 exports.move = async (req, res) => {
   try {
     const { pid, pls } = req.body;
+    const info = await GameInfo.findOne();
+    if (!info || info.gamestate < START_THRESHOLD) {
+      return res.status(400).json({ msg: '游戏未开始' });
+    }
     const player = await Player.findOne({ pid, uid: req.user._id });
     if (!player) return res.status(404).json({ msg: '玩家不存在' });
     player.pls = pls;
@@ -57,6 +66,10 @@ exports.move = async (req, res) => {
 exports.search = async (req, res) => {
   try {
     const { pid } = req.body;
+    const info = await GameInfo.findOne();
+    if (!info || info.gamestate < START_THRESHOLD) {
+      return res.status(400).json({ msg: '游戏未开始' });
+    }
     const player = await Player.findOne({ pid, uid: req.user._id });
     if (!player) return res.status(404).json({ msg: '玩家不存在' });
 

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -48,7 +48,8 @@ async function doMove() {
     log.value = data.msg
     info.value = data.player
   } catch (e) {
-    alert(e.response?.data?.msg || '移动失败')
+    const msg = e.response?.data?.msg
+    alert(msg || '移动失败')
   }
 }
 
@@ -59,7 +60,8 @@ async function doSearch() {
     log.value = data.log
     info.value = data.player
   } catch (e) {
-    alert(e.response?.data?.msg || '搜索失败')
+    const msg = e.response?.data?.msg
+    alert(msg || '搜索失败')
   }
 }
 </script>

--- a/frontend/src/pages/Start.vue
+++ b/frontend/src/pages/Start.vue
@@ -23,7 +23,8 @@ async function start() {
     playerInfo.value = status.data
     router.push('/game')
   } catch (e) {
-    alert(e.response?.data?.msg || '进入失败')
+    const msg = e.response?.data?.msg
+    alert(msg || '进入失败')
   }
 }
 


### PR DESCRIPTION
## Summary
- guard `enter`, `move` and `search` by game start state on backend
- bubble error messages on front‑end when game hasn't started

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68749969ed548322b606cefa3cc6e3d3