### PR TITLE
Enable map area CRUD in admin

### DIFF
--- a/backend/src/fieldsMeta.js
+++ b/backend/src/fieldsMeta.js
@@ -45,6 +45,11 @@ maptraps: [
   { name: 'itms', label: '用途/次数', type: 'text' },
   { name: 'pls', label: '布设区域', type: 'number' }
 ],
+  mapareas: [
+    { name: 'pid', label: '区域ID', type: 'number' },
+    { name: 'name', label: '区域名', type: 'text' },
+    { name: 'danger', label: '危险度', type: 'number' }
+  ],
 newsinfos: [
   { name: 'nid', label: '新闻ID', type: 'number' },
   { name: 'news', label: '内容', type: 'text' },

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -79,7 +79,8 @@ const collections = [
   { label: '历史记录', value: 'histories' },
   { label: '游戏信息', value: 'gameinfos' },
   { label: '用户', value: 'users' },
-  { label: '地图', value: 'maps' }
+  { label: '地图', value: 'maps' },
+  { label: '地图区域', value: 'mapareas' }
 ]
 
 const collection = ref('')
@@ -121,6 +122,13 @@ async function fetchItems() {
         name: d.name,
         players: d.players.map(p => `${p.name}(${p.pid})`).join(', ')
       }))
+    } else if (collection.value === 'mapareas') {
+      const { data } = await adminList('mapareas')
+      items.value = data
+      try {
+        const res = await getMapAreas()
+        mapAreas.value = res.data
+      } catch {}
     } else {
       const { data } = await adminList(collection.value)
       if (collection.value === 'players') {


### PR DESCRIPTION
## Summary
- define mapareas fields for admin metadata
- allow map area CRUD from admin page and refresh map list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874a1b5075883229f4c47a1fc1155a4