### PR TITLE
Implement rest timer and stamina bar

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -6,6 +6,16 @@ const MapArea = require('../models/MapArea');
 
 const START_THRESHOLD = 20;
 
+function applyRest(player) {
+  if (player.restStart) {
+    const sec = Math.floor((Date.now() - player.restStart) / 1000);
+    if (sec > 0) {
+      player.sp = Math.min(player.msp, player.sp + sec * 12);
+    }
+    player.restStart = 0;
+  }
+}
+
 exports.enter = async (req, res) => {
   try {
     const user = req.user;
@@ -52,12 +62,13 @@ exports.move = async (req, res) => {
     if (!info || info.gamestate < START_THRESHOLD) {
       return res.status(400).json({ msg: '游戏未开始' });
     }
-    const player = await Player.findOne({ pid, uid: req.user._id });
-    if (!player) return res.status(404).json({ msg: '玩家不存在' });
-    player.pls = pls;
-    await player.save();
-    const area = await MapArea.findOne({ pid: pls });
-    const name = area ? area.name : pls;
+  const player = await Player.findOne({ pid, uid: req.user._id });
+  if (!player) return res.status(404).json({ msg: '玩家不存在' });
+  applyRest(player);
+  player.pls = pls;
+  await player.save();
+  const area = await MapArea.findOne({ pid: pls });
+  const name = area ? area.name : pls;
     res.json({ msg: `移动到${name}`, player });
   } catch (err) {
     console.error(err);
@@ -72,10 +83,13 @@ exports.search = async (req, res) => {
     if (!info || info.gamestate < START_THRESHOLD) {
       return res.status(400).json({ msg: '游戏未开始' });
     }
-    const player = await Player.findOne({ pid, uid: req.user._id });
-    if (!player) return res.status(404).json({ msg: '玩家不存在' });
+  const player = await Player.findOne({ pid, uid: req.user._id });
+  if (!player) return res.status(404).json({ msg: '玩家不存在' });
 
-    let log = '';
+  applyRest(player);
+  player.sp = Math.max(player.sp - 12, 0);
+
+  let log = '';
 
     if (player.pls === 7 && Math.random() < 0.5) {
       const dmg = Math.floor(Math.random() * 10) + 1;
@@ -157,12 +171,11 @@ exports.list = async (req, res) => {
 exports.rest = async (req, res) => {
   try {
     const { pid } = req.body;
-    const player = await Player.findOne({ pid, uid: req.user._id });
-    if (!player) return res.status(404).json({ msg: '玩家不存在' });
-    player.hp = player.mhp;
-    player.sp = player.msp;
-    await player.save();
-    res.json({ msg: '你休息了一会儿。', player });
+  const player = await Player.findOne({ pid, uid: req.user._id });
+  if (!player) return res.status(404).json({ msg: '玩家不存在' });
+  player.restStart = Date.now();
+  await player.save();
+  res.json({ msg: '开始休息', player });
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: '休息失败' });

--- a/backend/src/models/Player.js
+++ b/backend/src/models/Player.js
@@ -118,6 +118,7 @@ const playerSchema = new mongoose.Schema({
   itme6: { type: Number, default: 0 },
   itms6: { type: String, default: '0' },
   itmsk6: { type: String, default: '' },
+  restStart: { type: Number, default: 0 },
   searchmemory: { type: String, default: '' },
   nskill: { type: String, default: '' },
   nskillpara: { type: String, default: '' }

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -3,8 +3,12 @@
     <h2>地图</h2>
     <el-descriptions v-if="info" border :column="2" style="margin-bottom:8px">
       <el-descriptions-item label="位置">{{ places[info.pls] }}</el-descriptions-item>
-      <el-descriptions-item label="生命">{{ info.hp }}/{{ info.mhp }}</el-descriptions-item>
-      <el-descriptions-item label="体力">{{ info.sp }}/{{ info.msp }}</el-descriptions-item>
+      <el-descriptions-item label="生命">
+        <el-progress :percentage="hpPercent" :text-inside="true" />
+      </el-descriptions-item>
+      <el-descriptions-item label="体力">
+        <el-progress :percentage="spPercent" :text-inside="true" />
+      </el-descriptions-item>
     </el-descriptions>
     <el-select v-model="target" placeholder="选择地点" style="width: 200px">
       <el-option v-for="(n,i) in places" :key="i" :label="n" :value="i" />
@@ -19,7 +23,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import Inventory from '../components/Inventory.vue'
 import { move, search, getStatus, getMapAreas, rest } from '../api'
 import { playerId } from '../store/user'
@@ -29,6 +33,13 @@ import { mapAreas as places } from '../store/map'
 const target = ref(0)
 const log = ref('')
 const showBag = ref(false)
+
+const hpPercent = computed(() =>
+  info.value ? Math.round((info.value.hp / info.value.mhp) * 100) : 0
+)
+const spPercent = computed(() =>
+  info.value ? Math.round((info.value.sp / info.value.msp) * 100) : 0
+)
 
 async function fetchStatus() {
   if (!playerId.value) return

--- a/frontend/src/pages/Status.vue
+++ b/frontend/src/pages/Status.vue
@@ -3,8 +3,12 @@
     <h2>角色状态</h2>
     <el-descriptions v-if="info" border :column="2" style="margin-top:10px">
       <el-descriptions-item label="位置">{{ place }}</el-descriptions-item>
-      <el-descriptions-item label="生命">{{ info.hp }}/{{ info.mhp }}</el-descriptions-item>
-      <el-descriptions-item label="体力">{{ info.sp }}/{{ info.msp }}</el-descriptions-item>
+      <el-descriptions-item label="生命">
+        <el-progress :percentage="hpPercent" :text-inside="true" />
+      </el-descriptions-item>
+      <el-descriptions-item label="体力">
+        <el-progress :percentage="spPercent" :text-inside="true" />
+      </el-descriptions-item>
     </el-descriptions>
   </div>
 </template>
@@ -17,6 +21,12 @@ import { mapAreas as places } from '../store/map'
 
 const info = ref(null)
 const place = computed(() => info.value ? places[info.value.pls] : '')
+const hpPercent = computed(() =>
+  info.value ? Math.round((info.value.hp / info.value.mhp) * 100) : 0
+)
+const spPercent = computed(() =>
+  info.value ? Math.round((info.value.sp / info.value.msp) * 100) : 0
+)
 
 async function fetch() {
   if (!playerId.value) return

--- a/mogoDB.md/players.md
+++ b/mogoDB.md/players.md
@@ -11,3 +11,17 @@ db.players.updateMany(
 ```
 
 该字段对应 `backend/src/models/Player.js` 中的 `uid`，类型为 `ObjectId`，引用 `users` 集合。
+
+## 新增 restStart 字段
+
+为实现休息计时，需要在 `players` 集合新增 `restStart` 字段，类型为 `Number`，记录开始休息的时间戳（毫秒）。
+
+```javascript
+use dts;
+db.players.updateMany(
+  { restStart: { $exists: false } },
+  { $set: { restStart: 0 } }
+)
+```
+
+该字段对应 `backend/src/models/Player.js` 中的 `restStart`。 


### PR DESCRIPTION
## Summary
- add `restStart` field for players and document in `mogoDB.md`
- compute stamina recovery after resting and deduct stamina when searching
- update `rest` to start timer
- show HP/SP bars in map and status pages

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874a6b173488322aeb7273d8729435f