### PR TITLE
Add scrollable log panel on game page

### DIFF
--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -14,21 +14,29 @@
     <el-button @click="doRest" style="margin-left:8px">休息</el-button>
     <el-button @click="showBag = true" style="margin-left:8px">背包</el-button>
     <p v-html="log" class="log"></p>
+    <div class="log-panel" v-if="logs.length">
+      <p v-for="(l,i) in logs" :key="i" v-html="l"></p>
+    </div>
     <Inventory v-model="showBag" />
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import Inventory from '../components/Inventory.vue'
 import { move, search, getStatus, getMapAreas, rest } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo as info } from '../store/player'
 import { mapAreas as places } from '../store/map'
+import { logs } from '../store/logs'
 
 const target = ref(0)
 const log = ref('')
 const showBag = ref(false)
+
+watch(log, val => {
+  if (val) logs.value.unshift(val)
+})
 
 async function fetchStatus() {
   if (!playerId.value) return
@@ -90,4 +98,12 @@ async function doRest() {
 
 <style scoped>
 .page { padding: 20px; }
+.log-panel {
+  max-height: 150px;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+  margin-top: 8px;
+  background: #f8f8f8;
+}
 </style>

--- a/frontend/src/store/logs.js
+++ b/frontend/src/store/logs.js
@@ -1,0 +1,11 @@
+import { ref, watch } from 'vue'
+
+export const logs = ref(JSON.parse(localStorage.getItem('logs') || '[]'))
+
+watch(logs, val => {
+  if (val && val.length) {
+    localStorage.setItem('logs', JSON.stringify(val.slice(0, 50)))
+  } else {
+    localStorage.removeItem('logs')
+  }
+}, { deep: true })


### PR DESCRIPTION
## Summary
- create `logs` store to save multiple logs
- update Map page to append logs and display history with scrolling

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874a701ade08322a737ea0d485a971f