### PR TITLE
Implement map item search with pool

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -89,6 +89,8 @@ exports.search = async (req, res) => {
   applyRest(player);
   player.sp = Math.max(player.sp - 12, 0);
 
+  const ITEM_FIND_RATE = 0.6;
+
   let log = '';
 
     if (player.pls === 7 && Math.random() < 0.5) {
@@ -107,22 +109,12 @@ exports.search = async (req, res) => {
       return res.json({ log, player });
     }
 
-    const item = await MapItem.findOne({ pls: player.pls });
-    if (item) {
-      for (let i = 0; i < 5; i++) {
-        if (!player[`itm${i}`]) {
-          player[`itm${i}`] = item.itm;
-          player[`itmk${i}`] = item.itmk;
-          player[`itme${i}`] = item.itme;
-          player[`itms${i}`] = item.itms;
-          player[`itmsk${i}`] = item.itmsk;
-          await MapItem.deleteOne({ _id: item._id });
-          log += `你找到了${item.itm}。<br>`;
-          break;
-        }
-      }
+    const items = await MapItem.find({ pls: player.pls });
+    if (items.length && Math.random() < ITEM_FIND_RATE) {
+      const item = items[Math.floor(Math.random() * items.length)];
+      log += `你发现了${item.itm}。<br>`;
       await player.save();
-      return res.json({ log, player });
+      return res.json({ log, player, item });
     }
 
     log += '但是没有发现任何东西。';
@@ -179,6 +171,35 @@ exports.rest = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: '休息失败' });
+  }
+};
+
+exports.pickItem = async (req, res) => {
+  try {
+    const { pid, itemId } = req.body;
+    const player = await Player.findOne({ pid, uid: req.user._id });
+    if (!player) return res.status(404).json({ msg: '玩家不存在' });
+
+    const item = await MapItem.findOne({ _id: itemId, pls: player.pls });
+    if (!item) return res.status(400).json({ msg: '物品不存在' });
+
+    let slot = -1;
+    for (let i = 0; i < 5; i++) {
+      if (!player[`itm${i}`]) { slot = i; break; }
+    }
+    if (slot === -1) return res.status(400).json({ msg: '物品栏已满' });
+
+    player[`itm${slot}`] = item.itm;
+    player[`itmk${slot}`] = item.itmk;
+    player[`itme${slot}`] = item.itme;
+    player[`itms${slot}`] = item.itms;
+    player[`itmsk${slot}`] = item.itmsk;
+    await item.deleteOne();
+    await player.save();
+    res.json({ msg: `获得了${item.itm}`, player });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '拾取失败' });
   }
 };
 

--- a/backend/src/routes/game.js
+++ b/backend/src/routes/game.js
@@ -15,6 +15,7 @@ router.post('/search', auth, playerController.search);
 router.get('/status', auth, playerController.status);
 router.get('/players', auth, playerController.list);
 router.post('/rest', auth, playerController.rest);
+router.post('/pick', auth, playerController.pickItem);
 router.post('/use', auth, playerController.useItem);
 router.post('/equip', auth, playerController.equip);
 

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -35,6 +35,7 @@ export const getStatus = pid => api.get('/game/status', { params: { pid } })
 export const getPlayers = () => api.get('/game/players')
 export const getMapAreas = () => api.get('/game/mapareas')
 export const rest = pid => api.post('/game/rest', { pid })
+export const pickItem = (pid, itemId) => api.post('/game/pick', { pid, itemId })
 export const useItem = (pid, index) => api.post('/game/use', { pid, index })
 export const equipItem = (pid, index) => api.post('/game/equip', { pid, index })
 

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -24,7 +24,7 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import InventoryPanel from '../components/InventoryPanel.vue'
-import { move, search, getStatus, getMapAreas, rest } from '../api'
+import { move, search, getStatus, getMapAreas, rest, pickItem } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo as info } from '../store/player'
 import { mapAreas as places } from '../store/map'
@@ -78,6 +78,18 @@ async function doSearch() {
     const { data } = await search(playerId.value)
     log.value = data.log
     info.value = data.player
+    if (data.item) {
+      if (confirm(`发现${data.item.itm}，是否拾取？`)) {
+        try {
+          const ret = await pickItem(playerId.value, data.item._id)
+          log.value += `<br>${ret.data.msg}`
+          info.value = ret.data.player
+        } catch (e) {
+          const msg = e.response?.data?.msg
+          alert(msg || '拾取失败')
+        }
+      }
+    }
   } catch (e) {
     const msg = e.response?.data?.msg
     alert(msg || '搜索失败')


### PR DESCRIPTION
## Summary
- implement map item pool and search probability on backend
- add API to pick items after searching
- connect new API from frontend
- prompt user to pick item when found

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6874a8d79ac0832292c01f99569e2827