### PR TITLE
实现地图物品搜索与拾取功能

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -87,7 +87,8 @@ exports.search = async (req, res) => {
   if (!player) return res.status(404).json({ msg: '玩家不存在' });
 
   applyRest(player);
-  player.sp = Math.max(player.sp - 12, 0);
+  const spCost = 15;
+  player.sp = Math.max(player.sp - spCost, 0);
 
   let log = '';
 
@@ -107,30 +108,54 @@ exports.search = async (req, res) => {
       return res.json({ log, player });
     }
 
-    const item = await MapItem.findOne({ pls: player.pls });
-    if (item) {
-      for (let i = 0; i < 5; i++) {
-        if (!player[`itm${i}`]) {
-          player[`itm${i}`] = item.itm;
-          player[`itmk${i}`] = item.itmk;
-          player[`itme${i}`] = item.itme;
-          player[`itms${i}`] = item.itms;
-          player[`itmsk${i}`] = item.itmsk;
-          await MapItem.deleteOne({ _id: item._id });
-          log += `你找到了${item.itm}。<br>`;
-          break;
-        }
+    let foundItem = null;
+    if (Math.random() < 0.6) {
+      const items = await MapItem.find({ pls: player.pls });
+      if (items.length) {
+        foundItem = items[Math.floor(Math.random() * items.length)];
+        log += `你找到了${foundItem.itm}。<br>`;
       }
-      await player.save();
-      return res.json({ log, player });
+    }
+
+    await player.save();
+    if (foundItem) {
+      return res.json({ log, player, item: foundItem });
     }
 
     log += '但是没有发现任何东西。';
-    await player.save();
     res.json({ log, player });
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: '搜索失败' });
+  }
+};
+
+exports.pickItem = async (req, res) => {
+  try {
+    const { pid, iid } = req.body;
+    const player = await Player.findOne({ pid, uid: req.user._id });
+    if (!player) return res.status(404).json({ msg: '玩家不存在' });
+    const item = await MapItem.findOne({ _id: iid, pls: player.pls });
+    if (!item) return res.status(404).json({ msg: '物品不存在' });
+    let slot = -1;
+    for (let i = 0; i < 5; i++) {
+      if (!player[`itm${i}`]) {
+        slot = i;
+        break;
+      }
+    }
+    if (slot === -1) return res.status(400).json({ msg: '背包已满' });
+    player[`itm${slot}`] = item.itm;
+    player[`itmk${slot}`] = item.itmk;
+    player[`itme${slot}`] = item.itme;
+    player[`itms${slot}`] = item.itms;
+    player[`itmsk${slot}`] = item.itmsk;
+    await item.deleteOne();
+    await player.save();
+    res.json({ msg: `获得了${item.itm}`, player });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '拾取失败' });
   }
 };
 

--- a/backend/src/routes/game.js
+++ b/backend/src/routes/game.js
@@ -17,5 +17,6 @@ router.get('/players', auth, playerController.list);
 router.post('/rest', auth, playerController.rest);
 router.post('/use', auth, playerController.useItem);
 router.post('/equip', auth, playerController.equip);
+router.post('/pick', auth, playerController.pickItem);
 
 module.exports = router;

--- a/data/initData.js
+++ b/data/initData.js
@@ -16,4 +16,11 @@ if (shopitems.length) {
   db.shopitems.insertMany(shopitems);
 }
 
+// 导入 mapitems
+var mapitems = JSON.parse(cat('./mapitems.json'));
+if (mapitems.length) {
+  db.mapitems.remove({});
+  db.mapitems.insertMany(mapitems);
+}
+
 print('数据导入完成');

--- a/data/mapitems.json
+++ b/data/mapitems.json
@@ -1,0 +1,5 @@
+[
+  {"iid": 1, "itm": "煤气罐", "itmk": "GBi", "itme": 1, "itms": "10", "itmsk": "", "pls": 0},
+  {"iid": 2, "itm": "增幅设备", "itmk": "X", "itme": 1, "itms": "1", "itmsk": "", "pls": 1},
+  {"iid": 3, "itm": "手枪子弹", "itmk": "GB", "itme": 1, "itms": "12", "itmsk": "", "pls": 2}
+]

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -37,6 +37,7 @@ export const getMapAreas = () => api.get('/game/mapareas')
 export const rest = pid => api.post('/game/rest', { pid })
 export const useItem = (pid, index) => api.post('/game/use', { pid, index })
 export const equipItem = (pid, index) => api.post('/game/equip', { pid, index })
+export const pickItem = (pid, iid) => api.post('/game/pick', { pid, iid })
 
 export const adminList = col => api.get(`/admin/${col}`)
 export const adminCreate = (col, data) => api.post(`/admin/${col}`, data)

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -48,7 +48,7 @@
 
 <script setup>
 import { ref, onMounted, computed, watch } from 'vue'
-import { move, search, getStatus, getMapAreas, rest } from '../api'
+import { move, search, getStatus, getMapAreas, rest, pickItem } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo as info } from '../store/player'
 import { mapAreas as places } from '../store/map'
@@ -107,6 +107,13 @@ async function doSearch() {
     const { data } = await search(playerId.value)
     log.value = data.log
     info.value = data.player
+    if (data.item) {
+      if (confirm(`发现 ${data.item.itm} ，是否拾取？`)) {
+        const res = await pickItem(playerId.value, data.item._id)
+        info.value = res.data.player
+        log.value += `<br>获得了${data.item.itm}`
+      }
+    }
   } catch (e) {
     alert(e.response?.data?.msg || '搜索失败')
   }

--- a/mogoDB.md/mapitems.md
+++ b/mogoDB.md/mapitems.md
@@ -6,8 +6,14 @@
 use dts;
 db.mapitems.insertMany([
   { iid: 1, itm: '煤气罐', itmk: 'GBi', itme: 1, itms: '10', itmsk: '', pls: 0 },
-  { iid: 2, itm: '增幅设备', itmk: 'X', itme: 1, itms: '1', itmsk: '', pls: 1 }
+ { iid: 2, itm: '增幅设备', itmk: 'X', itme: 1, itms: '1', itmsk: '', pls: 1 }
 ]);
+```
+
+项目根目录 `data` 目录提供了 `mapitems.json`，可直接导入：
+
+```bash
+mongoimport --db dts --collection mapitems --file ../data/mapitems.json --jsonArray
 ```
 
 以上字段对齐 `backend/src/models/MapItem.js`，仅为示例可按需修改。


### PR DESCRIPTION
## Summary
- 新增 `mapitems.json` 并在 `initData.js` 中导入
- 更新 `mapitems.md` 说明如何导入地面物品
- 调整玩家搜索逻辑，加入随机找物并记录体力消耗
- 新增 `pickItem` 接口用于拾取地面物品
- 更新前端调用逻辑，搜索到物品时询问是否拾取

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6874aa6606d48322a3b78c986807efd2