### PR TITLE
Fix missing watch import in Map page

### DIFF
--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, computed, watch } from 'vue'
 import InventoryPanel from '../components/InventoryPanel.vue'
 import { move, search, getStatus, getMapAreas, rest, pickItem } from '../api'
 


### PR DESCRIPTION
## Summary
- import `watch` from Vue in Map page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874b3550c208322b38225982b8ac1ac