### PR TITLE
Add map area and item pool data

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ npm run dev
 cd mogoDB.md
 mongoimport --db dts --collection gameinfos --file ../data/gameinfo.json --jsonArray
 mongoimport --db dts --collection shopitems --file ../data/shopitems.json --jsonArray
+mongoimport --db dts --collection mapareas --file ../data/mapareas.json --jsonArray
+mongoimport --db dts --collection mapitems --file ../data/mapitems.json --jsonArray
 ```
 
 也可以在 `mongo` shell 中执行 `data/initData.js` 脚本一次完成导入：
@@ -132,8 +134,8 @@ mongoimport --db dts --collection shopitems --file ../data/shopitems.json --json
 mongo ../data/initData.js
 ```
 
-导入完成后即可获得与原作一致的基础游戏信息及商店物品。
-此外，还需在 `mapareas` 集合中初始化地图区域信息，可在 `mongo` shell 中执行 `mogoDB.md/mapareas.md` 提供的示例语句。
+导入完成后即可获得与原作一致的基础游戏信息、地图区域以及示例物品池。
+如需手动添加地图或物品，可参照 `mogoDB.md/mapareas.md` 和 `mogoDB.md/mapitems.md` 的说明。
 
 ---
 

--- a/data/initData.js
+++ b/data/initData.js
@@ -16,6 +16,13 @@ if (shopitems.length) {
   db.shopitems.insertMany(shopitems);
 }
 
+// 导入 mapareas
+var mapareas = JSON.parse(cat('./mapareas.json'));
+if (mapareas.length) {
+  db.mapareas.remove({});
+  db.mapareas.insertMany(mapareas);
+}
+
 // 导入 mapitems
 var mapitems = JSON.parse(cat('./mapitems.json'));
 if (mapitems.length) {

--- a/data/mapareas.json
+++ b/data/mapareas.json
@@ -1,0 +1,5 @@
+[
+  {"pid": 0, "name": "墓地", "danger": 0},
+  {"pid": 1, "name": "教学楼", "danger": 0},
+  {"pid": 2, "name": "体育馆", "danger": 0}
+]

--- a/data/mapitems.json
+++ b/data/mapitems.json
@@ -1,5 +1,16 @@
 [
   {"iid": 1, "itm": "煤气罐", "itmk": "GBi", "itme": 1, "itms": "10", "itmsk": "", "pls": 0},
+  {"iid": 4, "itm": "精神制剂", "itmk": "HS", "itme": 75, "itms": "1", "itmsk": "", "pls": 0},
+  {"iid": 5, "itm": "伏特加", "itmk": "HS", "itme": 35, "itms": "1", "itmsk": "", "pls": 0},
+  {"iid": 6, "itm": "手枪子弹", "itmk": "GB", "itme": 1, "itms": "12", "itmsk": "", "pls": 0},
+
   {"iid": 2, "itm": "增幅设备", "itmk": "X", "itme": 1, "itms": "1", "itmsk": "", "pls": 1},
-  {"iid": 3, "itm": "手枪子弹", "itmk": "GB", "itme": 1, "itms": "12", "itmsk": "", "pls": 2}
+  {"iid": 7, "itm": "枪械电池", "itmk": "GBe", "itme": 1, "itms": "20", "itmsk": "", "pls": 1},
+  {"iid": 8, "itm": "精神制剂", "itmk": "HS", "itme": 75, "itms": "1", "itmsk": "", "pls": 1},
+  {"iid": 9, "itm": "手枪子弹", "itmk": "GB", "itme": 1, "itms": "12", "itmsk": "", "pls": 1},
+
+  {"iid": 3, "itm": "手枪子弹", "itmk": "GB", "itme": 1, "itms": "12", "itmsk": "", "pls": 2},
+  {"iid": 10, "itm": "棒球", "itmk": "WC", "itme": 12, "itms": "15", "itmsk": "", "pls": 2},
+  {"iid": 11, "itm": "霰弹枪", "itmk": "WG", "itme": 120, "itms": "4", "itmsk": "do", "pls": 2},
+  {"iid": 12, "itm": "地雷", "itmk": "TN", "itme": 200, "itms": "1", "itmsk": "", "pls": 2}
 ]

--- a/mogoDB.md/mapareas.md
+++ b/mogoDB.md/mapareas.md
@@ -18,3 +18,9 @@ db.mapareas.insertMany([
 ```javascript
 db.mapareas.createIndex({ pid: 1 }, { unique: true })
 ```
+
+也可以直接导入项目根目录 `data/mapareas.json` 提供的示例数据：
+
+```bash
+mongoimport --db dts --collection mapareas --file ../data/mapareas.json --jsonArray
+```

--- a/mogoDB.md/mapitems.md
+++ b/mogoDB.md/mapitems.md
@@ -16,4 +16,6 @@ db.mapitems.insertMany([
 mongoimport --db dts --collection mapitems --file ../data/mapitems.json --jsonArray
 ```
 
-以上字段对齐 `backend/src/models/MapItem.js`，仅为示例可按需修改。
+该文件内已包含与 `mapareas.json` 对应的三张地图示例物品池，可在后台管理界面实时增删改查。
+
+以上字段对齐 `backend/src/models/MapItem.js`，仅为示例可按需调整。


### PR DESCRIPTION
## Summary
- add `mapareas.json` and expand map item pools for each area
- import map areas and items via `initData.js`
- document import steps for map area/item pools
- update README with new initialization instructions

## Testing
- `npm test` (backend, expected failure: no tests)
- `npm test` (frontend, fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_6874b64929288322bbecacba949ba4e4