### PR TITLE
Add two-column layout to game interface

### DIFF
--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -1,48 +1,67 @@
 <template>
   <div class="map-page">
     <h2 class="title">游戏界面</h2>
+    <div class="layout">
+      <div class="left-panel">
+        <!-- 玩家数值区 -->
+        <el-card class="card-section" header="状态" v-if="info">
+          <p>玩家名：{{ info.name }}</p>
+          <p>攻击力：{{ info.att }}</p>
+          <p>防御力：{{ info.def }}</p>
+          <p>等级：{{ info.lvl }}</p>
+          <p>金钱：{{ info.money }}</p>
+        </el-card>
 
-    <!-- 地图状态栏 -->
-    <el-card class="card-section" shadow="hover">
-      <el-row :gutter="20">
-        <el-col :span="8"><strong>位置：</strong>{{ places[info.pls] }}</el-col>
-        <el-col :span="8">
-          <span class="label">生命：</span>
-          <el-progress :percentage="hpPercent" :text-inside="true" status="success" />
-        </el-col>
-        <el-col :span="8">
-          <span class="label">体力：</span>
-          <el-progress :percentage="spPercent" :text-inside="true" status="warning" />
-        </el-col>
-      </el-row>
-    </el-card>
+        <!-- 已装备列表 -->
+        <el-card class="card-section" header="已装备" v-if="info">
+          <el-table :data="equipRows" size="small" style="width: 100%">
+            <el-table-column prop="slot" label="装备种类" width="80" />
+            <el-table-column prop="name" label="装备名称" />
+            <el-table-column prop="attr" label="属性" width="80" />
+            <el-table-column prop="effect" label="效果" width="80" />
+            <el-table-column prop="dur" label="耐久" width="80" />
+          </el-table>
+        </el-card>
 
-    <!-- 操作区域 -->
-    <div class="action-bar">
-      <el-select v-model="target" placeholder="选择地点" style="width: 180px">
-        <el-option v-for="(n,i) in places" :key="i" :label="n" :value="i" />
-      </el-select>
-      <el-button type="primary" @click="doMove">移动</el-button>
-      <el-button @click="doSearch">搜索</el-button>
-      <el-button @click="doRest">休息</el-button>
+        <!-- 历史日志 -->
+        <el-card class="log-panel" shadow="never" v-if="logs.length">
+          <div v-for="(l, i) in logs" :key="i" v-html="l" class="log-item" />
+        </el-card>
+      </div>
+
+      <div class="right-panel">
+        <!-- 当前地图状态 -->
+        <el-card class="card-section" shadow="hover">
+          <el-row :gutter="20">
+            <el-col :span="8"><strong>位置：</strong>{{ places[info.pls] }}</el-col>
+            <el-col :span="8">
+              <span class="label">生命：</span>
+              <el-progress :percentage="hpPercent" :text-inside="true" status="success" />
+            </el-col>
+            <el-col :span="8">
+              <span class="label">体力：</span>
+              <el-progress :percentage="spPercent" :text-inside="true" status="warning" />
+            </el-col>
+          </el-row>
+        </el-card>
+
+        <!-- 行动区 -->
+        <div class="action-bar">
+          <el-select v-model="target" placeholder="选择地点" style="width: 180px">
+            <el-option v-for="(n,i) in places" :key="i" :label="n" :value="i" />
+          </el-select>
+          <el-button type="primary" @click="doMove">移动</el-button>
+          <el-button @click="doSearch">搜索</el-button>
+          <el-button @click="doRest">休息</el-button>
+        </div>
+
+        <!-- 最新日志 -->
+        <p v-if="log" v-html="log" class="log-current" />
+
+        <!-- 背包 -->
+        <InventoryPanel />
+      </div>
     </div>
-
-    <!-- 最新日志 -->
-    <p v-if="log" v-html="log" class="log-current" />
-
-    <!-- 日志历史 -->
-    <el-card class="log-panel" shadow="never" v-if="logs.length">
-      <div v-for="(l, i) in logs" :key="i" v-html="l" class="log-item" />
-    </el-card>
-
-    <!-- 装备信息 -->
-    <el-card class="card-section" header="装备">
-      <p>武器：{{ info.wep || '无' }}</p>
-      <p>防具：{{ info.arb || '无' }}</p>
-    </el-card>
-
-    <!-- 背包物品 -->
-    <InventoryPanel />
   </div>
 </template>
 
@@ -58,6 +77,18 @@ import { logs } from '../store/logs'
 
 const target = ref(0)
 const log = ref('')
+
+const equipRows = computed(() => {
+  if (!info.value) return []
+  return [
+    { slot: '武器', name: info.value.wep, attr: info.value.wepk, effect: info.value.wepe, dur: info.value.weps },
+    { slot: '身体', name: info.value.arb, attr: info.value.arbk, effect: info.value.arbe, dur: info.value.arbs },
+    { slot: '头部', name: info.value.arh, attr: info.value.arhk, effect: info.value.arhe, dur: info.value.arhs },
+    { slot: '手部', name: info.value.ara, attr: info.value.arak, effect: info.value.arae, dur: info.value.aras },
+    { slot: '腿部', name: info.value.arf, attr: info.value.arfk, effect: info.value.arfe, dur: info.value.arfs },
+    { slot: '装饰', name: info.value.art, attr: info.value.artk, effect: info.value.arte, dur: info.value.arts }
+  ]
+})
 
 function addLog(message) {
   log.value = message
@@ -145,6 +176,16 @@ async function doRest() {
   padding: 30px 20px;
   max-width: 880px;
   margin: 0 auto;
+}
+
+.layout {
+  display: flex;
+  gap: 20px;
+}
+
+.left-panel,
+.right-panel {
+  flex: 1;
 }
 
 .title {


### PR DESCRIPTION
## Summary
- reorganize Game page layout into left/right panels
- add player status and equipment list
- keep actions and inventory on the right side

## Testing
- `npm run lint` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_6874bc3d92d08322bfecadbb701b2c61