### PR TITLE
实现地图物品初始化并改进后台筛选

### DIFF
--- a/backend/src/controllers/gameController.js
+++ b/backend/src/controllers/gameController.js
@@ -2,6 +2,9 @@ const GameInfo = require('../models/GameInfo');
 const History = require('../models/History');
 const MapArea = require('../models/MapArea');
 const Player = require('../models/Player');
+const MapItem = require('../models/MapItem');
+const fs = require('fs');
+const path = require('path');
 
 exports.getInfo = async (req, res) => {
   try {
@@ -53,6 +56,19 @@ exports.startGame = async (req, res) => {
       info.areawarn = 0;
       await info.save();
     }
+
+    // 初始化地图物品
+    try {
+      const file = path.join(__dirname, '../../../data/mapitems.json');
+      const items = JSON.parse(fs.readFileSync(file));
+      await MapItem.deleteMany({});
+      if (items && items.length) {
+        await MapItem.insertMany(items);
+      }
+    } catch (e) {
+      console.error('初始化地图物品失败', e);
+    }
+
     res.json({ msg: '游戏已开始', gamestate: info.gamestate });
   } catch (err) {
     console.error(err);

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -60,7 +60,11 @@ router.get('/:collection', async (req, res) => {
   const Model = getModel(req.params.collection);
   if (!Model) return res.status(404).json({ msg: '集合不存在' });
   try {
-    const docs = await Model.find().limit(100);
+    const filter = {};
+    if (req.params.collection === 'mapitems' && req.query.pls !== undefined) {
+      filter.pls = Number(req.query.pls);
+    }
+    const docs = await Model.find(filter).limit(100);
     res.json(docs);
   } catch (err) {
     console.error(err);

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -39,7 +39,7 @@ export const pickItem = (pid, itemId) => api.post('/game/pick', { pid, itemId })
 export const useItem = (pid, index) => api.post('/game/use', { pid, index })
 export const equipItem = (pid, index) => api.post('/game/equip', { pid, index })
 
-export const adminList = col => api.get(`/admin/${col}`)
+export const adminList = (col, params = {}) => api.get(`/admin/${col}`, { params })
 export const adminCreate = (col, data) => api.post(`/admin/${col}`, data)
 export const adminUpdate = (col, id, data) => api.put(`/admin/${col}/${id}`, data)
 export const adminDelete = (col, id) => api.delete(`/admin/${col}/${id}`)

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -4,6 +4,15 @@
     <el-select v-model="collection" placeholder="选择集合" style="width: 200px">
       <el-option v-for="c in collections" :key="c.value" :label="c.label" :value="c.value" />
     </el-select>
+    <el-select
+      v-if="collection === 'mapitems'"
+      v-model="areaFilter"
+      placeholder="区域过滤"
+      style="width: 160px; margin-left:10px"
+    >
+      <el-option :label="'全部'" :value="-1" />
+      <el-option v-for="(n,i) in mapAreas" :key="i" :label="n" :value="i" />
+    </el-select>
     <el-button v-if="!isMaps" type="primary" size="small" @click="openCreate" style="margin-left:10px">新建</el-button>
     <el-table :data="items" style="margin-top: 20px" row-key="_id">
       <el-table-column prop="_id" label="ID" width="230" />
@@ -95,11 +104,15 @@ const editValue = ref('')
 const createDialogVisible = ref(false)
 const createData = ref({})
 const isMaps = computed(() => collection.value === 'maps')
+const areaFilter = ref(-1)
 
 watch(collection, () => {
   fetchFieldMeta()
   fetchItems()
 }, { immediate: true })
+watch(areaFilter, () => {
+  if (collection.value === 'mapitems') fetchItems()
+})
 
 async function fetchFieldMeta() {
   if (!collection.value) return
@@ -129,6 +142,17 @@ async function fetchItems() {
         const res = await getMapAreas()
         mapAreas.value = res.data
       } catch {}
+    } else if (collection.value === 'mapitems') {
+      if (!mapAreas.value.length) {
+        try {
+          const res = await getMapAreas()
+          mapAreas.value = res.data
+        } catch {}
+      }
+      const params = {}
+      if (areaFilter.value !== -1) params.pls = areaFilter.value
+      const { data } = await adminList('mapitems', params)
+      items.value = data
     } else {
       const { data } = await adminList(collection.value)
       if (collection.value === 'players') {


### PR DESCRIPTION
## Summary
- 在游戏开始时自动导入 `mapitems.json` 初始化地图道具
- 后台 `mapitems` 接口支持按地区过滤
- 前端 API 更新以传递查询参数
- 后台管理界面增加地图物品地区筛选下拉框

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874bcaccd7c832288b6943884caa565