### PR TITLE
Fix log and inventory persistence per player

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -61,7 +61,9 @@ import {
   stopGame,
   logout as logoutApi,
 } from '../api'
-import { user, token, refreshToken } from '../store/user'
+import { user, token, refreshToken, playerId } from '../store/user'
+import { playerInfo } from '../store/player'
+import { logs } from '../store/logs'
 
 const gameInfo = ref({})
 const currentTime = ref(Date.now())
@@ -143,6 +145,11 @@ async function login() {
     localStorage.setItem('user', user.value)
     localStorage.setItem('token', token.value)
     localStorage.setItem('refreshToken', refreshToken.value)
+    // reset player related info
+    playerId.value = ''
+    playerInfo.value = null
+    logs.value = []
+    localStorage.removeItem('playerId')
   } catch (e) {
     alert(e.response?.data?.msg || '登录失败')
   }
@@ -158,6 +165,10 @@ async function register() {
     localStorage.setItem('user', user.value)
     localStorage.setItem('token', token.value)
     localStorage.setItem('refreshToken', refreshToken.value)
+    playerId.value = ''
+    playerInfo.value = null
+    logs.value = []
+    localStorage.removeItem('playerId')
   } catch (e) {
     alert(e.response?.data?.msg || '注册失败')
   }
@@ -173,9 +184,13 @@ async function logout() {
   user.value = ''
   token.value = ''
   refreshToken.value = ''
+  playerId.value = ''
+  playerInfo.value = null
+  logs.value = []
   localStorage.removeItem('user')
   localStorage.removeItem('token')
   localStorage.removeItem('refreshToken')
+  localStorage.removeItem('playerId')
 }
 </script>
 

--- a/frontend/src/pages/Start.vue
+++ b/frontend/src/pages/Start.vue
@@ -11,6 +11,7 @@ import { useRouter } from 'vue-router'
 import { enterGame, getStatus } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo } from '../store/player'
+import { logs } from '../store/logs'
 
 const router = useRouter()
 
@@ -18,9 +19,9 @@ async function start() {
   try {
     const { data } = await enterGame()
     playerId.value = data.pid
-    localStorage.setItem('playerId', data.pid)
     const status = await getStatus(data.pid)
     playerInfo.value = status.data
+    logs.value = []
     router.push('/game')
   } catch (e) {
     const msg = e.response?.data?.msg

--- a/frontend/src/store/logs.js
+++ b/frontend/src/store/logs.js
@@ -1,11 +1,27 @@
 import { ref, watch } from 'vue'
+import { playerId } from './user'
 
-export const logs = ref(JSON.parse(localStorage.getItem('logs') || '[]'))
+export const logs = ref([])
+
+function loadLogs() {
+  if (!playerId.value) {
+    logs.value = []
+  } else {
+    logs.value = JSON.parse(localStorage.getItem(`logs_${playerId.value}`) || '[]')
+  }
+}
+
+loadLogs()
+
+watch(playerId, loadLogs)
 
 watch(logs, val => {
+  if (!playerId.value) return
   if (val && val.length) {
-    localStorage.setItem('logs', JSON.stringify(val.slice(0, 50)))
+    localStorage.setItem(`logs_${playerId.value}`, JSON.stringify(val.slice(0, 50)))
   } else {
-    localStorage.removeItem('logs')
+    localStorage.removeItem(`logs_${playerId.value}`)
   }
 }, { deep: true })
+
+export { loadLogs }

--- a/frontend/src/store/player.js
+++ b/frontend/src/store/player.js
@@ -1,11 +1,27 @@
 import { ref, watch } from 'vue'
+import { playerId } from './user'
 
-export const playerInfo = ref(JSON.parse(localStorage.getItem('playerInfo') || 'null'))
+export const playerInfo = ref(null)
+
+function loadPlayer() {
+  if (!playerId.value) {
+    playerInfo.value = null
+  } else {
+    playerInfo.value = JSON.parse(localStorage.getItem(`playerInfo_${playerId.value}`) || 'null')
+  }
+}
+
+loadPlayer()
+
+watch(playerId, loadPlayer)
 
 watch(playerInfo, val => {
+  if (!playerId.value) return
   if (val) {
-    localStorage.setItem('playerInfo', JSON.stringify(val))
+    localStorage.setItem(`playerInfo_${playerId.value}`, JSON.stringify(val))
   } else {
-    localStorage.removeItem('playerInfo')
+    localStorage.removeItem(`playerInfo_${playerId.value}`)
   }
 }, { deep: true })
+
+export { loadPlayer }

--- a/frontend/src/store/user.js
+++ b/frontend/src/store/user.js
@@ -1,6 +1,14 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 export const user = ref(localStorage.getItem('user') || '')
 export const token = ref(localStorage.getItem('token') || '')
 export const refreshToken = ref(localStorage.getItem('refreshToken') || '')
 export const playerId = ref(localStorage.getItem('playerId') || '')
+
+watch(playerId, val => {
+  if (val) {
+    localStorage.setItem('playerId', val)
+  } else {
+    localStorage.removeItem('playerId')
+  }
+})


### PR DESCRIPTION
## Summary
- bind playerId to localStorage with watcher
- store logs per-player and clear when user/login changes
- store player info per-player and clear on login/logout
- reset cached data during login/register/logout
- clear logs when a new player enters the game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874c1003b408322b63ad1d7d5f194c0