### PR TITLE
Improve item panel

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -138,34 +138,6 @@ exports.search = async (req, res) => {
   }
 };
 
-exports.pickItem = async (req, res) => {
-  try {
-    const { pid, iid } = req.body;
-    const player = await Player.findOne({ pid, uid: req.user._id });
-    if (!player) return res.status(404).json({ msg: '玩家不存在' });
-    const item = await MapItem.findOne({ _id: iid, pls: player.pls });
-    if (!item) return res.status(404).json({ msg: '物品不存在' });
-    let slot = -1;
-    for (let i = 0; i < 5; i++) {
-      if (!player[`itm${i}`]) {
-        slot = i;
-        break;
-      }
-    }
-    if (slot === -1) return res.status(400).json({ msg: '背包已满' });
-    player[`itm${slot}`] = item.itm;
-    player[`itmk${slot}`] = item.itmk;
-    player[`itme${slot}`] = item.itme;
-    player[`itms${slot}`] = item.itms;
-    player[`itmsk${slot}`] = item.itmsk;
-    await item.deleteOne();
-    await player.save();
-    res.json({ msg: `获得了${item.itm}`, player });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ msg: '拾取失败' });
-  }
-};
 
 exports.status = async (req, res) => {
   try {
@@ -327,5 +299,40 @@ exports.equip = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: '装备失败' });
+  }
+};
+
+exports.unequip = async (req, res) => {
+  try {
+    const { pid, slot } = req.body;
+    const player = await Player.findOne({ pid, uid: req.user._id });
+    if (!player) return res.status(404).json({ msg: '玩家不存在' });
+    const allow = ['wep', 'arb', 'arh', 'ara', 'arf', 'art'];
+    if (!allow.includes(slot)) return res.status(400).json({ msg: '装备栏错误' });
+    const name = player[slot];
+    if (!name) return res.status(400).json({ msg: '没有装备' });
+
+    let empty = -1;
+    for (let i = 0; i < 5; i++) {
+      if (!player[`itm${i}`]) { empty = i; break; }
+    }
+    if (empty === -1) return res.status(400).json({ msg: '物品栏已满' });
+
+    player[`itm${empty}`] = player[slot];
+    player[`itmk${empty}`] = player[`${slot}k`];
+    player[`itme${empty}`] = player[`${slot}e`];
+    player[`itms${empty}`] = player[`${slot}s`];
+    player[`itmsk${empty}`] = player[`${slot}sk`];
+
+    player[slot] = '';
+    player[`${slot}k`] = '';
+    player[`${slot}e`] = 0;
+    player[`${slot}s`] = '0';
+    player[`${slot}sk`] = '';
+    await player.save();
+    res.json({ msg: `卸下了${name}`, player });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '卸下失败' });
   }
 };

--- a/backend/src/routes/game.js
+++ b/backend/src/routes/game.js
@@ -18,6 +18,6 @@ router.post('/rest', auth, playerController.rest);
 router.post('/pick', auth, playerController.pickItem);
 router.post('/use', auth, playerController.useItem);
 router.post('/equip', auth, playerController.equip);
-router.post('/pick', auth, playerController.pickItem);
+router.post('/unequip', auth, playerController.unequip);
 
 module.exports = router;

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -38,6 +38,7 @@ export const rest = pid => api.post('/game/rest', { pid })
 export const pickItem = (pid, itemId) => api.post('/game/pick', { pid, itemId })
 export const useItem = (pid, index) => api.post('/game/use', { pid, index })
 export const equipItem = (pid, index) => api.post('/game/equip', { pid, index })
+export const unequipItem = (pid, slot) => api.post('/game/unequip', { pid, slot })
 
 export const adminList = (col, params = {}) => api.get(`/admin/${col}`, { params })
 export const adminCreate = (col, data) => api.post(`/admin/${col}`, data)

--- a/frontend/src/components/Inventory.vue
+++ b/frontend/src/components/Inventory.vue
@@ -9,10 +9,12 @@
       <h4 style="margin-top:10px">物品栏</h4>
       <el-table :data="items" style="width:100%">
         <el-table-column prop="name" label="物品" />
+        <el-table-column prop="type" label="类型" width="90" />
+        <el-table-column prop="effect" label="效果" width="90" />
         <el-table-column label="操作" width="150">
           <template #default="scope">
-            <el-button size="small" @click="equip(scope.$index)" :disabled="!scope.row.name">装备</el-button>
-            <el-button size="small" @click="useIt(scope.$index)" :disabled="!scope.row.name">使用</el-button>
+            <el-button size="small" @click="equip(scope.$index)" :disabled="scope.row.disableEquip">装备</el-button>
+            <el-button size="small" @click="useIt(scope.$index)" :disabled="scope.row.disableUse">使用</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -35,11 +37,38 @@ const visible = computed({
   set: v => emit('update:modelValue', v)
 })
 
+function getType(kind) {
+  if (!kind) return ''
+  if (kind.startsWith('HB')) return '命体恢复'
+  if (kind.startsWith('HS')) return '体力恢复'
+  if (kind.startsWith('HH') || kind.startsWith('HR')) return '生命恢复'
+  if (kind.startsWith('W')) return '武器'
+  if (kind.startsWith('DB')) return '身体装备'
+  if (kind.startsWith('DH')) return '头部装备'
+  if (kind.startsWith('DA')) return '手部装备'
+  if (kind.startsWith('DF')) return '腿部装备'
+  if (kind.startsWith('A')) return '饰品'
+  return '其他'
+}
+
+function isEquip(kind) {
+  return /^(W|DB|DH|DA|DF|A)/.test(kind)
+}
+
 const items = computed(() => {
   const res = []
   if (!info.value) return res
   for (let i = 0; i < 5; i++) {
-    res.push({ name: info.value[`itm${i}`] || '' })
+    const name = info.value[`itm${i}`] || ''
+    const kind = info.value[`itmk${i}`] || ''
+    const effect = info.value[`itme${i}`]
+    res.push({
+      name,
+      type: getType(kind),
+      effect: effect,
+      disableEquip: !name || !isEquip(kind),
+      disableUse: !name || isEquip(kind)
+    })
   }
   return res
 })

--- a/frontend/src/components/InventoryPanel.vue
+++ b/frontend/src/components/InventoryPanel.vue
@@ -4,10 +4,12 @@
       <h4 style="margin-top:10px">物品栏</h4>
       <el-table :data="items" style="width:100%">
         <el-table-column prop="name" label="物品" />
+        <el-table-column prop="type" label="类型" width="90" />
+        <el-table-column prop="effect" label="效果" width="90" />
         <el-table-column label="操作" width="150">
           <template #default="scope">
-            <el-button size="small" @click="equip(scope.$index)" :disabled="!scope.row.name">装备</el-button>
-            <el-button size="small" @click="useIt(scope.$index)" :disabled="!scope.row.name">使用</el-button>
+            <el-button size="small" @click="equip(scope.$index)" :disabled="scope.row.disableEquip">装备</el-button>
+            <el-button size="small" @click="useIt(scope.$index)" :disabled="scope.row.disableUse">使用</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -21,11 +23,38 @@ import { playerInfo as info } from '../store/player'
 import { playerId } from '../store/user'
 import { equipItem, useItem } from '../api'
 
+function getType(kind) {
+  if (!kind) return ''
+  if (kind.startsWith('HB')) return '命体恢复'
+  if (kind.startsWith('HS')) return '体力恢复'
+  if (kind.startsWith('HH') || kind.startsWith('HR')) return '生命恢复'
+  if (kind.startsWith('W')) return '武器'
+  if (kind.startsWith('DB')) return '身体装备'
+  if (kind.startsWith('DH')) return '头部装备'
+  if (kind.startsWith('DA')) return '手部装备'
+  if (kind.startsWith('DF')) return '腿部装备'
+  if (kind.startsWith('A')) return '饰品'
+  return '其他'
+}
+
+function isEquip(kind) {
+  return /^(W|DB|DH|DA|DF|A)/.test(kind)
+}
+
 const items = computed(() => {
   const res = []
   if (!info.value) return res
   for (let i = 0; i < 5; i++) {
-    res.push({ name: info.value[`itm${i}`] || '' })
+    const name = info.value[`itm${i}`] || ''
+    const kind = info.value[`itmk${i}`] || ''
+    const effect = info.value[`itme${i}`]
+    res.push({
+      name,
+      type: getType(kind),
+      effect: effect,
+      disableEquip: !name || !isEquip(kind),
+      disableUse: !name || isEquip(kind)
+    })
   }
   return res
 })

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -21,6 +21,11 @@
             <el-table-column prop="attr" label="属性" width="80" />
             <el-table-column prop="effect" label="效果" width="80" />
             <el-table-column prop="dur" label="耐久" width="80" />
+            <el-table-column label="操作" width="80">
+              <template #default="scope">
+                <el-button size="small" @click="unequip(scope.row.field)" :disabled="!scope.row.name">卸下</el-button>
+              </template>
+            </el-table-column>
           </el-table>
         </el-card>
 
@@ -74,7 +79,7 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import InventoryPanel from '../components/InventoryPanel.vue'
-import { move, search, getStatus, getMapAreas, rest, pickItem } from '../api'
+import { move, search, getStatus, getMapAreas, rest, pickItem, unequipItem } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo as info } from '../store/player'
 import { mapAreas as places } from '../store/map'
@@ -98,12 +103,12 @@ const spPercent = computed(() =>
 const equipRows = computed(() => {
   if (!info.value) return []
   return [
-    { slot: '武器', name: info.value.wep, attr: info.value.wepk, effect: info.value.wepe, dur: info.value.weps },
-    { slot: '身体', name: info.value.arb, attr: info.value.arbk, effect: info.value.arbe, dur: info.value.arbs },
-    { slot: '头部', name: info.value.arh, attr: info.value.arhk, effect: info.value.arhe, dur: info.value.arhs },
-    { slot: '手部', name: info.value.ara, attr: info.value.arak, effect: info.value.arae, dur: info.value.aras },
-    { slot: '腿部', name: info.value.arf, attr: info.value.arfk, effect: info.value.arfe, dur: info.value.arfs },
-    { slot: '装饰', name: info.value.art, attr: info.value.artk, effect: info.value.arte, dur: info.value.arts }
+    { slot: '武器', field: 'wep', name: info.value.wep, attr: info.value.wepk, effect: info.value.wepe, dur: info.value.weps },
+    { slot: '身体', field: 'arb', name: info.value.arb, attr: info.value.arbk, effect: info.value.arbe, dur: info.value.arbs },
+    { slot: '头部', field: 'arh', name: info.value.arh, attr: info.value.arhk, effect: info.value.arhe, dur: info.value.arhs },
+    { slot: '手部', field: 'ara', name: info.value.ara, attr: info.value.arak, effect: info.value.arae, dur: info.value.aras },
+    { slot: '腿部', field: 'arf', name: info.value.arf, attr: info.value.arfk, effect: info.value.arfe, dur: info.value.arfs },
+    { slot: '装饰', field: 'art', name: info.value.art, attr: info.value.artk, effect: info.value.arte, dur: info.value.arts }
   ]
 })
 
@@ -127,6 +132,17 @@ onMounted(() => {
   if (info.value) target.value = info.value.pls
   else fetchStatus()
 })
+
+async function unequip(field) {
+  if (!playerId.value) return
+  try {
+    const { data } = await unequipItem(playerId.value, field)
+    info.value = data.player
+    addLog(data.msg)
+  } catch (e) {
+    alert(e.response?.data?.msg || '卸下失败')
+  }
+}
 
 async function doMove() {
   if (!playerId.value) return


### PR DESCRIPTION
## Summary
- add unequip API on server
- expose new endpoint to clients
- show item type and effects in inventory components
- disable invalid actions by item type
- allow unequipping items via map page
- remove duplicate pickItem handler

## Testing
- `npm run lint` (backend) *(fails: Missing script)*
- `npm run lint` (frontend) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6874c3e4533083228a53c48a94f06040