### PR TITLE
Add more player attributes to status views

### DIFF
--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -10,7 +10,10 @@
           <p>攻击力：{{ info.att }}</p>
           <p>防御力：{{ info.def }}</p>
           <p>等级：{{ info.lvl }}</p>
+          <p>经验值：{{ info.exp }}</p>
           <p>金钱：{{ info.money }}</p>
+          <p>熟练度：殴{{ info.wp }} 斩{{ info.wk }} 射{{ info.wg }} 投{{ info.wc }} 爆{{ info.wd }} 灵{{ info.wf }}</p>
+          <p>受伤：{{ injuries }}</p>
         </el-card>
 
         <!-- 已装备列表（无标题） -->
@@ -99,6 +102,12 @@ const hpPercent = computed(() =>
 const spPercent = computed(() =>
   info.value ? Math.round((info.value.sp / info.value.msp) * 100) : 0
 )
+const injuries = computed(() => {
+  if (!info.value || !info.value.inf) return '无'
+  const map = { b: '胸', h: '头', a: '腕', f: '足' }
+  const arr = [...info.value.inf].map(c => map[c]).filter(Boolean)
+  return arr.length ? arr.join('、') : '无'
+})
 
 const equipRows = computed(() => {
   if (!info.value) return []

--- a/frontend/src/pages/Status.vue
+++ b/frontend/src/pages/Status.vue
@@ -9,6 +9,12 @@
       <el-descriptions-item label="体力">
         <el-progress :percentage="spPercent" :text-inside="true" />
       </el-descriptions-item>
+      <el-descriptions-item label="等级">{{ info.lvl }}</el-descriptions-item>
+      <el-descriptions-item label="经验">{{ info.exp }}</el-descriptions-item>
+      <el-descriptions-item label="熟练度">
+        <div v-for="p in profs" :key="p.label">{{ p.label }}: {{ p.val }}</div>
+      </el-descriptions-item>
+      <el-descriptions-item label="受伤部位">{{ injuries }}</el-descriptions-item>
     </el-descriptions>
   </div>
 </template>
@@ -27,6 +33,23 @@ const hpPercent = computed(() =>
 const spPercent = computed(() =>
   info.value ? Math.round((info.value.sp / info.value.msp) * 100) : 0
 )
+const profs = computed(() => {
+  if (!info.value) return []
+  return [
+    { label: '殴', val: info.value.wp },
+    { label: '斩', val: info.value.wk },
+    { label: '射', val: info.value.wg },
+    { label: '投', val: info.value.wc },
+    { label: '爆', val: info.value.wd },
+    { label: '灵', val: info.value.wf }
+  ]
+})
+const injuries = computed(() => {
+  if (!info.value || !info.value.inf) return '无'
+  const map = { b: '胸', h: '头', a: '腕', f: '足' }
+  const arr = [...info.value.inf].map(c => map[c]).filter(Boolean)
+  return arr.length ? arr.join('、') : '无'
+})
 
 async function fetch() {
   if (!playerId.value) return


### PR DESCRIPTION
## Summary
- extend Status page to display level, experience, proficiencies and injuries
- show experience, proficiencies and injury info on Map page

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874c78065b48322b96053e767101646