### PR TITLE
Fix closing game resets players

### DIFF
--- a/backend/src/controllers/gameController.js
+++ b/backend/src/controllers/gameController.js
@@ -69,6 +69,14 @@ exports.startGame = async (req, res) => {
       console.error('初始化地图物品失败', e);
     }
 
+    // 开局前清理旧玩家数据
+    try {
+      await Player.deleteMany({});
+      await require('../models/User').updateMany({}, { lastgame: 0, lastpid: 0 });
+    } catch (e) {
+      console.error('清理旧玩家数据失败', e);
+    }
+
     res.json({ msg: '游戏已开始', gamestate: info.gamestate });
   } catch (err) {
     console.error(err);
@@ -101,6 +109,13 @@ exports.stopGame = async (req, res) => {
       info.gamestate = 0;
       info.starttime = 0;
       await info.save();
+    }
+    // 归档后清理玩家与用户关联
+    try {
+      await Player.deleteMany({});
+      await require('../models/User').updateMany({}, { lastgame: 0, lastpid: 0 });
+    } catch (e) {
+      console.error('清理玩家数据失败', e);
     }
     res.json({ msg: '游戏已停止', gamestate: info.gamestate });
   } catch (err) {

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -130,6 +130,10 @@ async function manualStop() {
   try {
     await stopGame()
     fetchGameInfo()
+    playerId.value = ''
+    playerInfo.value = null
+    logs.value = []
+    localStorage.removeItem('playerId')
   } catch (e) {
     alert(e.response?.data?.msg || '操作失败')
   }


### PR DESCRIPTION
## Summary
- clear leftover player data when starting or stopping a game
- clear local player info after manual stop in home page

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6874ca762a9c8322b8f1f13385e4431a