### PR TITLE
Improve item search UI and pickup

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -438,3 +438,92 @@ exports.unequip = async (req, res) => {
     res.status(500).json({ msg: '卸下失败' });
   }
 };
+
+exports.pickReplace = async (req, res) => {
+  try {
+    const { pid, itemId, index } = req.body;
+    const player = await Player.findOne({ pid, uid: req.user._id });
+    if (!player) return res.status(404).json({ msg: '玩家不存在' });
+    if (index < 0 || index >= 5) return res.status(400).json({ msg: '物品编号错误' });
+
+    const item = await MapItem.findOne({ _id: itemId, pls: player.pls });
+    if (!item) return res.status(400).json({ msg: '物品不存在' });
+
+    const dropName = player[`itm${index}`];
+    const dropKind = player[`itmk${index}`];
+    const dropEffect = player[`itme${index}`];
+    const dropUses = player[`itms${index}`];
+    const dropSkill = player[`itmsk${index}`];
+
+    if (dropName) {
+      await MapItem.create({
+        itm: dropName,
+        itmk: dropKind,
+        itme: dropEffect,
+        itms: dropUses,
+        itmsk: dropSkill,
+        pls: player.pls
+      });
+    }
+
+    player[`itm${index}`] = item.itm;
+    player[`itmk${index}`] = item.itmk;
+    player[`itme${index}`] = item.itme;
+    player[`itms${index}`] = item.itms;
+    player[`itmsk${index}`] = item.itmsk;
+
+    await item.deleteOne();
+    await player.save();
+    res.json({ msg: `获得了${item.itm}`, player });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '拾取失败' });
+  }
+};
+
+exports.pickEquip = async (req, res) => {
+  try {
+    const { pid, itemId } = req.body;
+    const player = await Player.findOne({ pid, uid: req.user._id });
+    if (!player) return res.status(404).json({ msg: '玩家不存在' });
+
+    const item = await MapItem.findOne({ _id: itemId, pls: player.pls });
+    if (!item) return res.status(400).json({ msg: '物品不存在' });
+
+    let slotName = '';
+    if (item.itmk.startsWith('W')) slotName = 'wep';
+    else if (item.itmk.startsWith('DB')) slotName = 'arb';
+    else if (item.itmk.startsWith('DH')) slotName = 'arh';
+    else if (item.itmk.startsWith('DA')) slotName = 'ara';
+    else if (item.itmk.startsWith('DF')) slotName = 'arf';
+    else if (item.itmk.startsWith('A')) slotName = 'art';
+    else return res.status(400).json({ msg: '无法装备该物品' });
+
+    if (player[slotName]) {
+      let empty = -1;
+      for (let i = 0; i < 5; i++) {
+        if (!player[`itm${i}`]) { empty = i; break; }
+      }
+      if (empty === -1) return res.status(400).json({ msg: '物品栏已满，无法替换装备' });
+
+      player[`itm${empty}`] = player[slotName];
+      player[`itmk${empty}`] = player[`${slotName}k`];
+      player[`itme${empty}`] = player[`${slotName}e`];
+      player[`itms${empty}`] = player[`${slotName}s`];
+      player[`itmsk${empty}`] = player[`${slotName}sk`];
+    }
+
+    player[slotName] = item.itm;
+    player[`${slotName}k`] = item.itmk;
+    player[`${slotName}e`] = item.itme;
+    player[`${slotName}s`] = item.itms;
+    player[`${slotName}sk`] = item.itmsk;
+
+    await item.deleteOne();
+    await player.save();
+    res.json({ msg: `装备了${item.itm}`, player });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '装备失败' });
+  }
+};

--- a/backend/src/routes/game.js
+++ b/backend/src/routes/game.js
@@ -16,6 +16,8 @@ router.get('/status', auth, playerController.status);
 router.get('/players', auth, playerController.list);
 router.post('/rest', auth, playerController.rest);
 router.post('/pick', auth, playerController.pickItem);
+router.post('/pickreplace', auth, playerController.pickReplace);
+router.post('/pickequip', auth, playerController.pickEquip);
 router.post('/use', auth, playerController.useItem);
 router.post('/equip', auth, playerController.equip);
 router.post('/unequip', auth, playerController.unequip);

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -36,6 +36,10 @@ export const getPlayers = () => api.get('/game/players')
 export const getMapAreas = () => api.get('/game/mapareas')
 export const rest = pid => api.post('/game/rest', { pid })
 export const pickItem = (pid, itemId) => api.post('/game/pick', { pid, itemId })
+export const pickReplace = (pid, itemId, index) =>
+  api.post('/game/pickreplace', { pid, itemId, index })
+export const pickEquip = (pid, itemId) =>
+  api.post('/game/pickequip', { pid, itemId })
 export const useItem = (pid, index) => api.post('/game/use', { pid, index })
 export const equipItem = (pid, index) => api.post('/game/equip', { pid, index })
 export const unequipItem = (pid, slot) => api.post('/game/unequip', { pid, slot })

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -69,11 +69,32 @@
           <el-button @click="doRest">休息</el-button>
         </div>
 
+        <!-- 搜索结果 -->
+        <div v-if="foundItem" class="card-section search-result">
+          <p>发现 {{ foundItem.itm }}</p>
+          <el-button size="small" @click="pickFound">拾取</el-button>
+          <el-button size="small" v-if="isEquip(foundItem.itmk)" @click="equipFound">装备</el-button>
+        </div>
+
         <!-- 最新日志 -->
         <p v-if="log" v-html="log" class="log-current" />
 
         <!-- 背包面板 -->
         <InventoryPanel />
+
+        <el-dialog v-model="replaceVisible" title="选择替换物品" width="400px">
+          <el-table :data="bagItems" style="width:100%">
+            <el-table-column prop="name" label="物品" />
+            <el-table-column prop="type" label="类型" width="90" />
+            <el-table-column prop="effect" label="效果" width="70" />
+            <el-table-column prop="uses" label="耐久" width="60" />
+            <el-table-column label="操作" width="80">
+              <template #default="scope">
+                <el-button size="small" @click="doReplace(scope.$index)">替换</el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+        </el-dialog>
       </div>
     </div>
   </div>
@@ -82,7 +103,7 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
 import InventoryPanel from '../components/InventoryPanel.vue'
-import { move, search, getStatus, getMapAreas, rest, pickItem, unequipItem } from '../api'
+import { move, search, getStatus, getMapAreas, rest, pickItem, pickReplace, pickEquip, unequipItem } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo as info } from '../store/player'
 import { mapAreas as places } from '../store/map'
@@ -90,6 +111,45 @@ import { logs } from '../store/logs'
 
 const target = ref(0)
 const log = ref('')
+const foundItem = ref(null)
+const replaceVisible = ref(false)
+let replaceItemId = null
+
+function getType(kind) {
+  if (!kind) return ''
+  if (kind.startsWith('HB')) return '命体恢复'
+  if (kind.startsWith('HS')) return '体力恢复'
+  if (kind.startsWith('HH') || kind.startsWith('HR')) return '生命恢复'
+  if (kind.startsWith('W')) return '武器'
+  if (kind.startsWith('DB')) return '身体装备'
+  if (kind.startsWith('DH')) return '头部装备'
+  if (kind.startsWith('DA')) return '手部装备'
+  if (kind.startsWith('DF')) return '腿部装备'
+  if (kind.startsWith('A')) return '饰品'
+  return '其他'
+}
+
+function isEquip(kind) {
+  return /^(W|DB|DH|DA|DF|A)/.test(kind)
+}
+
+const bagItems = computed(() => {
+  const res = []
+  if (!info.value) return res
+  for (let i = 0; i < 5; i++) {
+    const name = info.value[`itm${i}`] || ''
+    const kind = info.value[`itmk${i}`] || ''
+    const effect = info.value[`itme${i}`]
+    const uses = info.value[`itms${i}`]
+    res.push({
+      name,
+      type: getType(kind),
+      effect,
+      uses
+    })
+  }
+  return res
+})
 
 function addLog(message) {
   log.value = message
@@ -169,20 +229,8 @@ async function doSearch() {
   try {
     const { data } = await search(playerId.value)
     info.value = data.player
-    let message = data.log
-    if (data.item) {
-      if (confirm(`发现${data.item.itm}，是否拾取？`)) {
-        try {
-          const ret = await pickItem(playerId.value, data.item._id)
-          message += `<br>${ret.data.msg}`
-          info.value = ret.data.player
-        } catch (e) {
-          const msg = e.response?.data?.msg
-          alert(msg || '拾取失败')
-        }
-      }
-    }
-    addLog(message)
+    foundItem.value = data.item || null
+    addLog(data.log)
   } catch (e) {
     alert(e.response?.data?.msg || '搜索失败')
   }
@@ -196,6 +244,49 @@ async function doRest() {
     addLog(data.msg)
   } catch (e) {
     alert(e.response?.data?.msg || '休息失败')
+  }
+}
+
+async function pickFound() {
+  if (!playerId.value || !foundItem.value) return
+  try {
+    const { data } = await pickItem(playerId.value, foundItem.value._id)
+    info.value = data.player
+    addLog(data.msg)
+    foundItem.value = null
+  } catch (e) {
+    const msg = e.response?.data?.msg
+    if (msg === '物品栏已满') {
+      replaceItemId = foundItem.value._id
+      replaceVisible.value = true
+    } else {
+      alert(msg || '拾取失败')
+    }
+  }
+}
+
+async function equipFound() {
+  if (!playerId.value || !foundItem.value) return
+  try {
+    const { data } = await pickEquip(playerId.value, foundItem.value._id)
+    info.value = data.player
+    addLog(data.msg)
+    foundItem.value = null
+  } catch (e) {
+    alert(e.response?.data?.msg || '装备失败')
+  }
+}
+
+async function doReplace(index) {
+  if (!playerId.value || replaceItemId === null) return
+  try {
+    const { data } = await pickReplace(playerId.value, replaceItemId, index)
+    info.value = data.player
+    addLog(data.msg)
+    replaceVisible.value = false
+    foundItem.value = null
+  } catch (e) {
+    alert(e.response?.data?.msg || '拾取失败')
   }
 }
 </script>
@@ -271,5 +362,9 @@ async function doRest() {
 .log-item {
   padding: 4px 0;
   border-bottom: 1px solid #eee;
+}
+
+.search-result {
+  background: #fdfdfd;
 }
 </style>


### PR DESCRIPTION
## Summary
- add API endpoints for replacing items and equipping directly from the map
- expose new APIs to frontend
- update game page to show search result panel with pick and equip buttons
- support replacing items when inventory is full

## Testing
- `npm test` (backend: expected failure)
- `npm test` (frontend: missing script)

------
https://chatgpt.com/codex/tasks/task_e_6874cbcafc00832288427ea9800fe675