### PR TITLE
Fix equipment replacement and item display

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -344,13 +344,22 @@ exports.equip = async (req, res) => {
       for (let i = 0; i < 5; i++) {
         if (!player[`itm${i}`]) { empty = i; break; }
       }
-      if (empty === -1) return res.status(400).json({ msg: '物品栏已满，无法替换装备' });
-
-      player[`itm${empty}`] = player[slotName];
-      player[`itmk${empty}`] = player[`${slotName}k`];
-      player[`itme${empty}`] = player[`${slotName}e`];
-      player[`itms${empty}`] = player[`${slotName}s`];
-      player[`itmsk${empty}`] = player[`${slotName}sk`];
+      if (empty !== -1) {
+        player[`itm${empty}`] = player[slotName];
+        player[`itmk${empty}`] = player[`${slotName}k`];
+        player[`itme${empty}`] = player[`${slotName}e`];
+        player[`itms${empty}`] = player[`${slotName}s`];
+        player[`itmsk${empty}`] = player[`${slotName}sk`];
+      } else {
+        await MapItem.create({
+          itm: player[slotName],
+          itmk: player[`${slotName}k`],
+          itme: player[`${slotName}e`],
+          itms: player[`${slotName}s`],
+          itmsk: player[`${slotName}sk`],
+          pls: player.pls
+        });
+      }
     }
 
     if (slotName === 'wep') {
@@ -504,13 +513,22 @@ exports.pickEquip = async (req, res) => {
       for (let i = 0; i < 5; i++) {
         if (!player[`itm${i}`]) { empty = i; break; }
       }
-      if (empty === -1) return res.status(400).json({ msg: '物品栏已满，无法替换装备' });
-
-      player[`itm${empty}`] = player[slotName];
-      player[`itmk${empty}`] = player[`${slotName}k`];
-      player[`itme${empty}`] = player[`${slotName}e`];
-      player[`itms${empty}`] = player[`${slotName}s`];
-      player[`itmsk${empty}`] = player[`${slotName}sk`];
+      if (empty !== -1) {
+        player[`itm${empty}`] = player[slotName];
+        player[`itmk${empty}`] = player[`${slotName}k`];
+        player[`itme${empty}`] = player[`${slotName}e`];
+        player[`itms${empty}`] = player[`${slotName}s`];
+        player[`itmsk${empty}`] = player[`${slotName}sk`];
+      } else {
+        await MapItem.create({
+          itm: player[slotName],
+          itmk: player[`${slotName}k`],
+          itme: player[`${slotName}e`],
+          itms: player[`${slotName}s`],
+          itmsk: player[`${slotName}sk`],
+          pls: player.pls
+        });
+      }
     }
 
     player[slotName] = item.itm;

--- a/frontend/src/components/Inventory.vue
+++ b/frontend/src/components/Inventory.vue
@@ -62,13 +62,13 @@ const items = computed(() => {
   for (let i = 0; i < 5; i++) {
     const name = info.value[`itm${i}`] || ''
     const kind = info.value[`itmk${i}`] || ''
-    const effect = info.value[`itme${i}`]
-    const uses = info.value[`itms${i}`]
+    const effect = name ? info.value[`itme${i}`] : ''
+    const uses = name ? info.value[`itms${i}`] : ''
     res.push({
       name,
       type: getType(kind),
-      effect: effect,
-      uses: uses,
+      effect,
+      uses,
       disableEquip: !name || !isEquip(kind),
       disableUse: !name || isEquip(kind)
     })

--- a/frontend/src/components/InventoryPanel.vue
+++ b/frontend/src/components/InventoryPanel.vue
@@ -48,13 +48,13 @@ const items = computed(() => {
   for (let i = 0; i < 5; i++) {
     const name = info.value[`itm${i}`] || ''
     const kind = info.value[`itmk${i}`] || ''
-    const effect = info.value[`itme${i}`]
-    const uses = info.value[`itms${i}`]
+    const effect = name ? info.value[`itme${i}`] : ''
+    const uses = name ? info.value[`itms${i}`] : ''
     res.push({
       name,
       type: getType(kind),
-      effect: effect,
-      uses: uses,
+      effect,
+      uses,
       disableEquip: !name || !isEquip(kind),
       disableUse: !name || isEquip(kind)
     })

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -139,8 +139,8 @@ const bagItems = computed(() => {
   for (let i = 0; i < 5; i++) {
     const name = info.value[`itm${i}`] || ''
     const kind = info.value[`itmk${i}`] || ''
-    const effect = info.value[`itme${i}`]
-    const uses = info.value[`itms${i}`]
+    const effect = name ? info.value[`itme${i}`] : ''
+    const uses = name ? info.value[`itms${i}`] : ''
     res.push({
       name,
       type: getType(kind),
@@ -172,12 +172,12 @@ const injuries = computed(() => {
 const equipRows = computed(() => {
   if (!info.value) return []
   return [
-    { slot: '武器', field: 'wep', name: info.value.wep, attr: info.value.wepk, effect: info.value.wepe, dur: info.value.weps },
-    { slot: '身体', field: 'arb', name: info.value.arb, attr: info.value.arbk, effect: info.value.arbe, dur: info.value.arbs },
-    { slot: '头部', field: 'arh', name: info.value.arh, attr: info.value.arhk, effect: info.value.arhe, dur: info.value.arhs },
-    { slot: '手部', field: 'ara', name: info.value.ara, attr: info.value.arak, effect: info.value.arae, dur: info.value.aras },
-    { slot: '腿部', field: 'arf', name: info.value.arf, attr: info.value.arfk, effect: info.value.arfe, dur: info.value.arfs },
-    { slot: '装饰', field: 'art', name: info.value.art, attr: info.value.artk, effect: info.value.arte, dur: info.value.arts }
+    { slot: '武器', field: 'wep', name: info.value.wep, attr: info.value.wepk, effect: info.value.wep ? info.value.wepe : '', dur: info.value.wep ? info.value.weps : '' },
+    { slot: '身体', field: 'arb', name: info.value.arb, attr: info.value.arbk, effect: info.value.arb ? info.value.arbe : '', dur: info.value.arb ? info.value.arbs : '' },
+    { slot: '头部', field: 'arh', name: info.value.arh, attr: info.value.arhk, effect: info.value.arh ? info.value.arhe : '', dur: info.value.arh ? info.value.arhs : '' },
+    { slot: '手部', field: 'ara', name: info.value.ara, attr: info.value.arak, effect: info.value.ara ? info.value.arae : '', dur: info.value.ara ? info.value.aras : '' },
+    { slot: '腿部', field: 'arf', name: info.value.arf, attr: info.value.arfk, effect: info.value.arf ? info.value.arfe : '', dur: info.value.arf ? info.value.arfs : '' },
+    { slot: '装饰', field: 'art', name: info.value.art, attr: info.value.artk, effect: info.value.art ? info.value.arte : '', dur: info.value.art ? info.value.arts : '' }
   ]
 })
 


### PR DESCRIPTION
## Summary
- allow equipping new items even if bag is full by dropping old equipment
- clean up inventory display when slots are empty

## Testing
- `npm run build` in `frontend`
- `npm install` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6874ce2da5708322815b31c9e3cab437