### PR TITLE
Enable auto move after selecting map

### DIFF
--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -61,8 +61,13 @@
 
         <!-- 行动按钮区 -->
         <div class="action-bar">
-          <el-select v-model="target" placeholder="选择地点" style="width: 180px">
-            <el-option v-for="(n,i) in places" :key="i" :label="n" :value="i" />
+          <el-select
+            v-model="target"
+            placeholder="选择地点"
+            style="width: 180px"
+            @change="onTargetChange"
+          >
+            <el-option v-for="(n, i) in places" :key="i" :label="n" :value="i" />
           </el-select>
           <el-button type="primary" @click="doMove">移动</el-button>
           <el-button @click="doSearch">搜索</el-button>
@@ -115,6 +120,20 @@ const target = ref(0)
 const foundItem = ref(null)
 const replaceVisible = ref(false)
 let replaceItemId = null
+let programmatic = false
+
+function setTarget(val) {
+  programmatic = true
+  target.value = val
+}
+
+function onTargetChange() {
+  if (programmatic) {
+    programmatic = false
+  } else {
+    doMove()
+  }
+}
 
 function getType(kind) {
   if (!kind) return ''
@@ -192,7 +211,7 @@ async function fetchStatus() {
   try {
     const { data } = await getStatus(playerId.value)
     info.value = data
-    target.value = data.pls
+    setTarget(data.pls)
   } catch {
     info.value = null
   }
@@ -204,7 +223,7 @@ onMounted(() => {
       places.value = data
     }).catch(() => {})
   }
-  if (info.value) target.value = info.value.pls
+  if (info.value) setTarget(info.value.pls)
   else fetchStatus()
 })
 


### PR DESCRIPTION
## Summary
- trigger movement when changing map selection
- prevent automatic triggers during page init

## Testing
- `npm install` *(frontend)*
- `npm run build` *(frontend)*
- `npm test` *(backend)*

------
https://chatgpt.com/codex/tasks/task_e_6875e2b215608322b6314b3c394faaa2