### PR TITLE
Fix missing club options on start

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,12 +2,31 @@ const express = require('express');
 const mongoose = require('mongoose');
 const redis = require('redis');
 const cors = require('cors');
+const fs = require('fs');
+const path = require('path');
 require('dotenv').config();
 
 const authRoutes = require('./routes/auth');
 const gameRoutes = require('./routes/game');
 const adminRoutes = require('./routes/admin');
 const userRoutes = require('./routes/user');
+const Club = require('./models/Club');
+
+async function ensureDefaultClubs() {
+  const count = await Club.countDocuments();
+  if (count === 0) {
+    try {
+      const file = path.join(__dirname, '../../data/clubs.json');
+      const clubs = JSON.parse(fs.readFileSync(file));
+      if (clubs && clubs.length) {
+        await Club.insertMany(clubs);
+        console.log('已导入默认职业列表');
+      }
+    } catch (e) {
+      console.error('导入默认职业列表失败', e);
+    }
+  }
+}
 
 const app = express();
 app.use(cors());
@@ -15,7 +34,10 @@ app.use(express.json());
 
 const mongoUri = process.env.MONGODB_URI;
 mongoose.connect(mongoUri)
-  .then(() => console.log('MongoDB 已连接'))
+  .then(async () => {
+    console.log('MongoDB 已连接');
+    await ensureDefaultClubs();
+  })
   .catch(err => console.error('MongoDB 连接失败', err));
 
 const redisClient = redis.createClient({ url: process.env.REDIS_URL });

--- a/mogoDB.md/clubs.md
+++ b/mogoDB.md/clubs.md
@@ -10,3 +10,5 @@
    db.clubs.deleteMany({})
    db.clubs.insertMany(JSON.parse(cat('data/clubs.json')))
    ```
+5. 从 `v1.1` 起，后端在启动时会自动检查 `clubs` 集合，若为空则读取
+   `data/clubs.json` 写入默认职业列表，可在日志中看到提示。


### PR DESCRIPTION
## Summary
- seed default clubs on server startup if `clubs` collection is empty
- document auto-seeding in `mogoDB.md`

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6875f0edd6e88322b0b130d6b222ce8f