### PR TITLE
Refine search event order

### DIFF
--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -106,25 +106,31 @@ async function search(user, body) {
 
   // 3. 遭遇敌人事件
   const enemies = await Player.find({ pls: player.pls, hp: { $gt: 0 }, pid: { $ne: pid } });
-  if (enemies.length && Math.random() < 0.5) {
+  if (enemies.length) {
     const enemy = enemies[Math.floor(Math.random() * enemies.length)];
-    if (enemy.type > 0) {
-      if (Math.random() < 0.5) {
-        const dmg = Math.floor(Math.random() * 10) + 1;
-        player.hp = Math.max(player.hp - dmg, 0);
-        log += `NPC【${enemy.name}】的伏击使你受到${dmg}点伤害！<br>`;
-        if (player.hp <= 0) {
-          player.state = 27;
-          log += '你遭到致命打击！<br>';
+    let chance = 0.5 + (player.sp - enemy.sp) / 200;
+    if (enemy.type > 0) chance -= 0.05;
+    if (chance < 0.05) chance = 0.05;
+    if (chance > 0.95) chance = 0.95;
+    if (Math.random() < chance) {
+      if (enemy.type > 0) {
+        if (enemy.sp > player.sp) {
+          const dmg = Math.floor(Math.random() * 10) + 1;
+          player.hp = Math.max(player.hp - dmg, 0);
+          log += `NPC【${enemy.name}】的伏击使你受到${dmg}点伤害！<br>`;
+          if (player.hp <= 0) {
+            player.state = 27;
+            log += '你遭到致命打击！<br>';
+          }
+        } else {
+          log += `你发现了NPC【${enemy.name}】，可以选择攻击。<br>`;
         }
       } else {
-        log += `你发现了NPC【${enemy.name}】，可以选择攻击。<br>`;
+        log += `你发现了玩家【${enemy.name}】！<br>`;
       }
-    } else {
-      log += `你发现了玩家【${enemy.name}】！<br>`;
+      await player.save();
+      return { log, player, enemy: { pid: enemy.pid, name: enemy.name, type: enemy.type } };
     }
-    await player.save();
-    return { log, player, enemy: { pid: enemy.pid, name: enemy.name, type: enemy.type } };
   }
 
   const items = await MapItem.find({ pls: player.pls });

--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -77,6 +77,7 @@ async function search(user, body) {
 
   let log = '';
 
+  // 1. 特殊地图事件
   if (player.pls === 7 && Math.random() < 0.5) {
     const dmg = Math.floor(Math.random() * 10) + 1;
     player.sp = Math.max(player.sp - dmg, 0);
@@ -85,6 +86,7 @@ async function search(user, body) {
     return { log, player };
   }
 
+  // 2. 陷阱事件
   if (Math.random() < 0.05) {
     const traps = await MapTrap.find({ pls: player.pls });
     if (traps.length) {
@@ -100,6 +102,29 @@ async function search(user, body) {
       await player.save();
       return { log, player };
     }
+  }
+
+  // 3. 遭遇敌人事件
+  const enemies = await Player.find({ pls: player.pls, hp: { $gt: 0 }, pid: { $ne: pid } });
+  if (enemies.length && Math.random() < 0.5) {
+    const enemy = enemies[Math.floor(Math.random() * enemies.length)];
+    if (enemy.type > 0) {
+      if (Math.random() < 0.5) {
+        const dmg = Math.floor(Math.random() * 10) + 1;
+        player.hp = Math.max(player.hp - dmg, 0);
+        log += `NPC【${enemy.name}】的伏击使你受到${dmg}点伤害！<br>`;
+        if (player.hp <= 0) {
+          player.state = 27;
+          log += '你遭到致命打击！<br>';
+        }
+      } else {
+        log += `你发现了NPC【${enemy.name}】，可以选择攻击。<br>`;
+      }
+    } else {
+      log += `你发现了玩家【${enemy.name}】！<br>`;
+    }
+    await player.save();
+    return { log, player, enemy: { pid: enemy.pid, name: enemy.name, type: enemy.type } };
   }
 
   const items = await MapItem.find({ pls: player.pls });


### PR DESCRIPTION
## Summary
- reorder search logic with explicit steps
- add enemy encounter step between trap and item events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68760c8918088322af49393bbf553f44