### PR TITLE
Implement dynamic attack/defense stats

### DIFF
--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -4,7 +4,7 @@ const MapArea = require('../../models/MapArea');
 const MapItem = require('../../models/MapItem');
 const MapTrap = require('../../models/MapTrap');
 const { START_THRESHOLD } = require('../../config/constants');
-const { applyRest, restoreMemoryItem } = require('./utils');
+const { applyRest, restoreMemoryItem, formatPlayer } = require('./utils');
 
 async function move(user, body) {
   const { pid, pls } = body;
@@ -41,7 +41,7 @@ async function move(user, body) {
 
   const area = await MapArea.findOne({ pid: pls });
   const name = area ? area.name : pls;
-  return { msg: `移动到${name}`, player };
+  return { msg: `移动到${name}`, player: formatPlayer(player) };
 }
 
 async function search(user, body) {
@@ -83,7 +83,7 @@ async function search(user, body) {
     player.sp = Math.max(player.sp - dmg, 0);
     log += `你脚下一滑摔进池里，消耗${dmg}点体力。<br>`;
     await player.save();
-    return { log, player };
+    return { log, player: formatPlayer(player) };
   }
 
   // 2. 陷阱事件
@@ -100,7 +100,7 @@ async function search(user, body) {
         log += '你被陷阱杀死了！<br>';
       }
       await player.save();
-      return { log, player };
+      return { log, player: formatPlayer(player) };
     }
   }
 
@@ -129,7 +129,7 @@ async function search(user, body) {
         log += `你发现了玩家【${enemy.name}】！<br>`;
       }
       await player.save();
-      return { log, player, enemy: { pid: enemy.pid, name: enemy.name, type: enemy.type } };
+      return { log, player: formatPlayer(player), enemy: { pid: enemy.pid, name: enemy.name, type: enemy.type } };
     }
   }
 
@@ -148,12 +148,12 @@ async function search(user, body) {
     });
     log += `你发现了${item.itm}。<br>`;
     await player.save();
-    return { log, player, item };
+    return { log, player: formatPlayer(player), item };
   }
 
   log += '但是没有发现任何东西。';
   await player.save();
-  return { log, player };
+  return { log, player: formatPlayer(player) };
 }
 
 async function status(user, query) {
@@ -169,7 +169,7 @@ async function status(user, query) {
     err.status = 400;
     throw err;
   }
-  return player;
+  return formatPlayer(player);
 }
 
 async function list(user) {
@@ -201,7 +201,7 @@ async function rest(user, body) {
   }
   player.restStart = Date.now();
   await player.save();
-  return { msg: '开始休息', player };
+  return { msg: '开始休息', player: formatPlayer(player) };
 }
 
 module.exports = { move, search, status, list, rest };

--- a/backend/src/services/player/items.js
+++ b/backend/src/services/player/items.js
@@ -1,7 +1,7 @@
 const Player = require('../../models/Player');
 const MapItem = require('../../models/MapItem');
 const { dropMapItem } = require('./utils');
-const { checkAmmoKind, bulletNames, reduceItem } = require('./utils');
+const { checkAmmoKind, bulletNames, reduceItem, formatPlayer } = require('./utils');
 
 async function pickItem(user, body) {
   const { pid, itemId } = body;
@@ -42,7 +42,7 @@ async function pickItem(user, body) {
   player[`itmsk${slot}`] = item.itmsk;
   player.searchmemory = '';
   await player.save();
-  return { msg: `获得了${item.itm}`, player };
+  return { msg: `获得了${item.itm}`, player: formatPlayer(player) };
 }
 
 async function useItem(user, body) {
@@ -164,7 +164,7 @@ async function useItem(user, body) {
   }
 
   await player.save();
-  return { msg: log, player };
+  return { msg: log, player: formatPlayer(player) };
 }
 
 async function equip(user, body) {
@@ -279,7 +279,7 @@ async function equip(user, body) {
   player[`itms${index}`] = '0';
   player[`itmsk${index}`] = '';
   await player.save();
-  return { msg: `装备了${name}`, player };
+  return { msg: `装备了${name}`, player: formatPlayer(player) };
 }
 
 async function unequip(user, body) {
@@ -330,7 +330,7 @@ async function unequip(user, body) {
   player[`${slot}s`] = '0';
   player[`${slot}sk`] = '';
   await player.save();
-  return { msg: `卸下了${name}`, player };
+  return { msg: `卸下了${name}`, player: formatPlayer(player) };
 }
 
 async function pickReplace(user, body) {
@@ -385,7 +385,7 @@ async function pickReplace(user, body) {
   player.searchmemory = '';
 
   await player.save();
-  return { msg: `获得了${item.itm}`, player, dropName };
+  return { msg: `获得了${item.itm}`, player: formatPlayer(player), dropName };
 }
 
 async function pickEquip(user, body) {
@@ -454,7 +454,7 @@ async function pickEquip(user, body) {
 
   player.searchmemory = '';
   await player.save();
-  return { msg: `装备了${item.itm}`, player };
+  return { msg: `装备了${item.itm}`, player: formatPlayer(player) };
 }
 
 module.exports = {

--- a/backend/src/services/player/utils.js
+++ b/backend/src/services/player/utils.js
@@ -59,11 +59,20 @@ const bulletNames = {
   GBe: '能源弹药'
 };
 
+function formatPlayer(player) {
+  const data = player.toObject ? player.toObject() : { ...player };
+  data.att = data.att + (data.wepe || 0) * 2;
+  data.def = data.def + (data.arbe || 0) + (data.arhe || 0) +
+    (data.arae || 0) + (data.arfe || 0) + (data.arte || 0);
+  return data;
+}
+
 module.exports = {
   applyRest,
   reduceItem,
   checkAmmoKind,
   bulletNames,
   dropMapItem,
-  restoreMemoryItem
+  restoreMemoryItem,
+  formatPlayer
 };


### PR DESCRIPTION
## Summary
- compute final attack and defense values when returning player data
- update equip/unequip and action flows to include formatted player info

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68761315f01c832285b052c68da02e71