### PR TITLE
Enhance rest stamina update

### DIFF
--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -169,6 +169,8 @@ async function status(user, query) {
     err.status = 400;
     throw err;
   }
+  applyRest(player);
+  await player.save();
   return player;
 }
 

--- a/backend/src/services/player/utils.js
+++ b/backend/src/services/player/utils.js
@@ -2,11 +2,15 @@ const { dropMapItem, restoreMemoryItem } = require('../../utils/item');
 
 function applyRest(player) {
   if (player.restStart) {
-    const sec = Math.floor((Date.now() - player.restStart) / 1000);
+    const now = Date.now();
+    const sec = Math.floor((now - player.restStart) / 1000);
     if (sec > 0) {
       player.sp = Math.min(player.msp, player.sp + sec * 12);
+      player.restStart += sec * 1000;
+      if (player.sp >= player.msp) {
+        player.restStart = 0;
+      }
     }
-    player.restStart = 0;
   }
 }
 

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import InventoryPanel from '../components/InventoryPanel.vue'
 import PlayerStats from '../components/PlayerStats.vue'
 import EquipmentList from '../components/EquipmentList.vue'
@@ -74,6 +74,7 @@ const foundItem = ref(null)
 const replaceVisible = ref(false)
 let replaceItemId = null
 let programmatic = false
+let restTimer = null
 
 function setTarget(val) {
   if (target.value !== val) {
@@ -161,12 +162,28 @@ const equipRows = computed(() => {
   ]
 })
 
+function startRestMonitor() {
+  if (restTimer) clearInterval(restTimer)
+  restTimer = setInterval(async () => {
+    if (!playerId.value) return
+    try {
+      const { data } = await getStatus(playerId.value)
+      info.value = data
+      if (!data.restStart) {
+        clearInterval(restTimer)
+        restTimer = null
+      }
+    } catch {}
+  }, 1000)
+}
+
 async function fetchStatus() {
   if (!playerId.value) return
   try {
     const { data } = await getStatus(playerId.value)
     info.value = data
     setTarget(data.pls)
+    if (data.restStart) startRestMonitor()
   } catch {
     info.value = null
   }
@@ -180,6 +197,11 @@ onMounted(() => {
   }
   if (info.value) setTarget(info.value.pls)
   else fetchStatus()
+})
+
+onUnmounted(() => {
+  if (restTimer) clearInterval(restTimer)
+  restTimer = null
 })
 
 async function unequip(field) {
@@ -222,6 +244,7 @@ async function doRest() {
     const { data } = await rest(playerId.value)
     info.value = data.player
     addLog(data.msg)
+    startRestMonitor()
   } catch (e) {
     alert(e.response?.data?.msg || '休息失败')
   }


### PR DESCRIPTION
## Summary
- refresh stamina during rest continuously
- update applyRest logic to accumulate recovery
- poll player status on frontend while resting

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68761355d04083229979ad588c071b26