### PR TITLE
Improve rest stamina refresh

### DIFF
--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -5,7 +5,7 @@ const MapItem = require('../../models/MapItem');
 const MapTrap = require('../../models/MapTrap');
 const { START_THRESHOLD } = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
-const { applyRest, restoreMemoryItem } = require('./utils');
+const { applyRest, restoreMemoryItem, updateRest } = require('./utils');
 
 
 async function move(user, body) {
@@ -179,6 +179,8 @@ async function status(user, query) {
     err.status = 400;
     throw err;
   }
+  updateRest(player);
+  await player.save();
   return formatPlayer(player);
 }
 

--- a/backend/src/services/player/utils.js
+++ b/backend/src/services/player/utils.js
@@ -1,11 +1,21 @@
 const { dropMapItem, restoreMemoryItem } = require('../../utils/item');
 
+function updateRest(player) {
+  if (!player.restStart) return;
+  const now = Date.now();
+  const sec = Math.floor((now - player.restStart) / 1000);
+  if (sec <= 0) return;
+  player.sp = Math.min(player.msp, player.sp + sec * 12);
+  if (player.sp >= player.msp) {
+    player.restStart = 0;
+  } else {
+    player.restStart += sec * 1000;
+  }
+}
+
 function applyRest(player) {
+  updateRest(player);
   if (player.restStart) {
-    const sec = Math.floor((Date.now() - player.restStart) / 1000);
-    if (sec > 0) {
-      player.sp = Math.min(player.msp, player.sp + sec * 12);
-    }
     player.restStart = 0;
   }
 }
@@ -68,6 +78,7 @@ function formatPlayer(player) {
 }
 
 module.exports = {
+  updateRest,
   applyRest,
   reduceItem,
   checkAmmoKind,

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import InventoryPanel from '../components/InventoryPanel.vue'
 import PlayerStats from '../components/PlayerStats.vue'
@@ -77,10 +77,32 @@ const foundItem = ref(null)
 const replaceVisible = ref(false)
 let replaceItemId = null
 let programmatic = false
+let restTimer = null
 
 function checkDeath() {
   if (info.value && info.value.hp <= 0) {
     router.replace('/gameover')
+  }
+}
+
+function startRestTimer() {
+  if (restTimer) return
+  restTimer = setInterval(async () => {
+    if (!playerId.value) return
+    try {
+      const { data } = await getStatus(playerId.value)
+      info.value = data
+      if (!data.restStart) {
+        stopRestTimer()
+      }
+    } catch {}
+  }, 1000)
+}
+
+function stopRestTimer() {
+  if (restTimer) {
+    clearInterval(restTimer)
+    restTimer = null
   }
 }
 
@@ -177,6 +199,7 @@ async function fetchStatus() {
     info.value = data
     setTarget(data.pls)
     checkDeath()
+    return data
   } catch {
     info.value = null
   }
@@ -192,8 +215,13 @@ onMounted(() => {
   else fetchStatus()
 })
 
+onUnmounted(() => {
+  stopRestTimer()
+})
+
 async function unequip(field) {
   if (!playerId.value) return
+  stopRestTimer()
   try {
     const { data } = await unequipItem(playerId.value, field)
     info.value = data.player
@@ -205,6 +233,7 @@ async function unequip(field) {
 
 async function doMove() {
   if (!playerId.value) return
+  stopRestTimer()
   try {
     const { data } = await move(playerId.value, target.value)
     info.value = data.player
@@ -217,6 +246,7 @@ async function doMove() {
 
 async function doSearch() {
   if (!playerId.value) return
+  stopRestTimer()
   try {
     const { data } = await search(playerId.value)
     info.value = data.player
@@ -235,6 +265,9 @@ async function doRest() {
     info.value = data.player
     addLog(data.msg)
     checkDeath()
+    if (data.player.restStart) {
+      startRestTimer()
+    }
   } catch (e) {
     alert(e.response?.data?.msg || '休息失败')
   }
@@ -242,6 +275,7 @@ async function doRest() {
 
 async function pickFound() {
   if (!playerId.value || !foundItem.value) return
+  stopRestTimer()
   try {
     const { data } = await pickItem(playerId.value, foundItem.value._id)
     info.value = data.player
@@ -261,6 +295,7 @@ async function pickFound() {
 
 async function equipFound() {
   if (!playerId.value || !foundItem.value) return
+  stopRestTimer()
   try {
     const { data } = await pickEquip(playerId.value, foundItem.value._id)
     info.value = data.player
@@ -274,6 +309,7 @@ async function equipFound() {
 
 async function doReplace(index) {
   if (!playerId.value || replaceItemId === null) return
+  stopRestTimer()
   try {
     const { data } = await pickReplace(playerId.value, replaceItemId, index)
     info.value = data.player


### PR DESCRIPTION
## Summary
- add `updateRest` to refresh stamina while resting
- apply rest updates on status fetch
- auto-poll status in front-end when resting

## Testing
- `npm --prefix backend test` *(fails: Error: no test specified)*
- `npm --prefix frontend install`
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_68761685374883229319023fc9963a10