### PR TITLE
Fix missing formatPlayer import in player actions

### DIFF
--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -5,7 +5,7 @@ const MapItem = require('../../models/MapItem');
 const MapTrap = require('../../models/MapTrap');
 const { START_THRESHOLD } = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
-const { applyRest, restoreMemoryItem, updateRest } = require('./utils');
+const { applyRest, restoreMemoryItem, updateRest, formatPlayer } = require('./utils');
 
 
 async function move(user, body) {


### PR DESCRIPTION
## Summary
- import `formatPlayer` in `actions.js` to resolve ReferenceError

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68761950ef648322b9340a2d76bc218a