### PR TITLE
Fix token auto-refresh

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,5 +1,10 @@
 import axios from 'axios'
-import { token } from '../store/user'
+import { token, refreshToken } from '../store/user'
+
+// 独立实例用于刷新令牌，避免递归拦截
+const refreshRequest = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/api'
+})
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api'
@@ -11,5 +16,53 @@ api.interceptors.request.use(config => {
   }
   return config
 })
+
+let refreshing = false
+let pending = []
+
+function processPending(newToken) {
+  pending.forEach(cb => cb(newToken))
+  pending = []
+}
+
+api.interceptors.response.use(
+  res => res,
+  async error => {
+    const { config, response } = error
+    if (response && response.status === 401 && !config.__isRetry && refreshToken.value) {
+      config.__isRetry = true
+      if (!refreshing) {
+        refreshing = true
+        try {
+          const { data } = await refreshRequest.post('/auth/refresh', { refreshToken: refreshToken.value })
+          token.value = data.token
+          localStorage.setItem('token', token.value)
+          processPending(token.value)
+        } catch (e) {
+          token.value = ''
+          refreshToken.value = ''
+          localStorage.removeItem('token')
+          localStorage.removeItem('refreshToken')
+          processPending(null)
+          refreshing = false
+          return Promise.reject(e)
+        }
+        refreshing = false
+      }
+
+      return new Promise(resolve => {
+        pending.push(newToken => {
+          if (newToken) {
+            config.headers.Authorization = `Bearer ${newToken}`
+            resolve(api(config))
+          } else {
+            resolve(Promise.reject(error))
+          }
+        })
+      })
+    }
+    return Promise.reject(error)
+  }
+)
 
 export default api

--- a/frontend/src/store/user.js
+++ b/frontend/src/store/user.js
@@ -5,6 +5,30 @@ export const token = ref(localStorage.getItem('token') || '')
 export const refreshToken = ref(localStorage.getItem('refreshToken') || '')
 export const playerId = ref(localStorage.getItem('playerId') || '')
 
+watch(user, val => {
+  if (val) {
+    localStorage.setItem('user', val)
+  } else {
+    localStorage.removeItem('user')
+  }
+})
+
+watch(token, val => {
+  if (val) {
+    localStorage.setItem('token', val)
+  } else {
+    localStorage.removeItem('token')
+  }
+})
+
+watch(refreshToken, val => {
+  if (val) {
+    localStorage.setItem('refreshToken', val)
+  } else {
+    localStorage.removeItem('refreshToken')
+  }
+})
+
 watch(playerId, val => {
   if (val) {
     localStorage.setItem('playerId', val)


### PR DESCRIPTION
## Summary
- auto-refresh JWT token on 401 responses
- persist user and token data in localStorage via watchers

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68761d7864a88322835a1ccee7985b54