### PR TITLE
Parse start items and weapons

### DIFF
--- a/backend/src/services/player/entry.js
+++ b/backend/src/services/player/entry.js
@@ -3,6 +3,8 @@ const GameInfo = require('../../models/GameInfo');
 const Club = require('../../models/Club');
 const { START_THRESHOLD } = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
+const startItems = require('../../../../data/start_items.json');
+const startWeapons = require('../../../../data/start_weapons.json');
 
 async function clubs() {
   const clubs = await Club.find({}, 'cid name');
@@ -51,8 +53,56 @@ async function enter(user, body) {
       att: base.att,
       def: base.def,
       money: base.money,
-      club: club || 0
+      club: club || 0,
+      itm0: '面包',
+      itmk0: 'HH',
+      itme0: 100,
+      itms0: '30',
+      itmsk0: '',
+      itm1: '矿泉水',
+      itmk1: 'HS',
+      itme1: 100,
+      itms1: '30',
+      itmsk1: ''
     });
+
+    const weapon =
+      startWeapons[Math.floor(Math.random() * startWeapons.length)] || null;
+    if (weapon) {
+      player.wep = weapon.itm;
+      player.wepk = weapon.itmk;
+      player.wepe = weapon.itme;
+      player.weps = String(weapon.itms);
+      player.wepsk = weapon.itmsk || '';
+    }
+
+    function randItem() {
+      return startItems[Math.floor(Math.random() * startItems.length)];
+    }
+    let itemA = randItem();
+    let itemB = randItem();
+    let limit = 10;
+    while (itemB.itmk === itemA.itmk && limit > 0) {
+      itemB = randItem();
+      limit--;
+    }
+
+    if (itemA) {
+      player.itm2 = itemA.itm;
+      player.itmk2 = itemA.itmk;
+      player.itme2 = itemA.itme;
+      player.itms2 = String(itemA.itms);
+      player.itmsk2 = itemA.itmsk || '';
+    }
+    if (itemB) {
+      player.itm3 = itemB.itm;
+      player.itmk3 = itemB.itmk;
+      player.itme3 = itemB.itme;
+      player.itms3 = String(itemB.itms);
+      player.itmsk3 = itemB.itmsk || '';
+    }
+
+    await player.save();
     user.lastgame = gid;
     user.lastpid = pid;
     await user.save();

--- a/data/start_items.json
+++ b/data/start_items.json
@@ -1,0 +1,639 @@
+[
+  {
+    "itm": "生命探测器",
+    "itmk": "ER",
+    "itme": 3,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "生命探测器",
+    "itmk": "ER",
+    "itme": 3,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "生命探测器",
+    "itmk": "ER",
+    "itme": 3,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "生命探测器",
+    "itmk": "ER",
+    "itme": 3,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "毒药",
+    "itmk": "Y",
+    "itme": 1,
+    "itms": 2,
+    "itmsk": ""
+  },
+  {
+    "itm": "毒药",
+    "itmk": "Y",
+    "itme": 1,
+    "itms": 2,
+    "itmsk": ""
+  },
+  {
+    "itm": "毒药",
+    "itmk": "Y",
+    "itme": 1,
+    "itms": 2,
+    "itmsk": ""
+  },
+  {
+    "itm": "毒药",
+    "itmk": "Y",
+    "itme": 1,
+    "itms": 2,
+    "itmsk": ""
+  },
+  {
+    "itm": "解毒剂",
+    "itmk": "Cp",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "解毒剂",
+    "itmk": "Cp",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "烧伤药剂",
+    "itmk": "Cu",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "解冻药水",
+    "itmk": "Ci",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "麻痹药剂",
+    "itmk": "Ce",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "清醒药剂",
+    "itmk": "Cw",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "苹果酒",
+    "itmk": "HS",
+    "itme": 50,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "鸡尾酒",
+    "itmk": "HS",
+    "itme": 50,
+    "itms": 2,
+    "itmsk": ""
+  },
+  {
+    "itm": "威士忌酒",
+    "itmk": "HS",
+    "itme": 60,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "点心",
+    "itmk": "HS",
+    "itme": 50,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "手机",
+    "itmk": "WC",
+    "itme": 20,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "笔记本电脑",
+    "itmk": "WP",
+    "itme": 20,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "手机",
+    "itmk": "WC",
+    "itme": 20,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "笔记本电脑",
+    "itmk": "WP",
+    "itme": 20,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "信管",
+    "itmk": "X",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "信管",
+    "itmk": "X",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "信管",
+    "itmk": "X",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "导火线",
+    "itmk": "X",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "导火线",
+    "itmk": "X",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "导火线",
+    "itmk": "X",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "手枪子弹",
+    "itmk": "GB",
+    "itme": 1,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "手枪子弹",
+    "itmk": "GB",
+    "itme": 1,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "机枪子弹",
+    "itmk": "GBr",
+    "itme": 1,
+    "itms": 40,
+    "itmsk": ""
+  },
+  {
+    "itm": "机枪子弹",
+    "itmk": "GBr",
+    "itme": 1,
+    "itms": 40,
+    "itmsk": ""
+  },
+  {
+    "itm": "压缩气罐",
+    "itmk": "GBi",
+    "itme": 1,
+    "itms": 20,
+    "itmsk": ""
+  },
+  {
+    "itm": "枪械电池",
+    "itmk": "GBe",
+    "itme": 1,
+    "itms": 20,
+    "itmsk": ""
+  },
+  {
+    "itm": "水",
+    "itmk": "HS",
+    "itme": 70,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "水",
+    "itmk": "HS",
+    "itme": 70,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "水",
+    "itmk": "HS",
+    "itme": 70,
+    "itms": 8,
+    "itmsk": ""
+  },
+  {
+    "itm": "水",
+    "itmk": "HS",
+    "itme": 70,
+    "itms": 8,
+    "itmsk": ""
+  },
+  {
+    "itm": "地雷",
+    "itmk": "TN",
+    "itme": 300,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "地雷",
+    "itmk": "TN",
+    "itme": 300,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "绳索",
+    "itmk": "TN",
+    "itme": 120,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "绳索",
+    "itmk": "TN",
+    "itme": 120,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "绳索",
+    "itmk": "TN",
+    "itme": 120,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "绳索",
+    "itmk": "TN",
+    "itme": 120,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "★阔剑地雷★",
+    "itmk": "TN",
+    "itme": 450,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "★阔剑地雷★",
+    "itmk": "TN",
+    "itme": 450,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "警用盾牌",
+    "itmk": "DA",
+    "itme": 52,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "绝缘手套",
+    "itmk": "DA",
+    "itme": 12,
+    "itms": 15,
+    "itmsk": "E"
+  },
+  {
+    "itm": "简易盾牌",
+    "itmk": "DA",
+    "itme": 35,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "皮手套",
+    "itmk": "DA",
+    "itme": 15,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "手表",
+    "itmk": "DA",
+    "itme": 10,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "手链",
+    "itmk": "DA",
+    "itme": 2,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "垫肩",
+    "itmk": "DA",
+    "itme": 5,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "简易盾牌",
+    "itmk": "DA",
+    "itme": 35,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "皮手套",
+    "itmk": "DA",
+    "itme": 15,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "手表",
+    "itmk": "DA",
+    "itme": 10,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "手链",
+    "itmk": "DA",
+    "itme": 2,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "垫肩",
+    "itmk": "DA",
+    "itme": 5,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "核电站工作服",
+    "itmk": "DB",
+    "itme": 45,
+    "itms": 20,
+    "itmsk": "U"
+  },
+  {
+    "itm": "特种部队制服",
+    "itmk": "DB",
+    "itme": 40,
+    "itms": 20,
+    "itmsk": "G"
+  },
+  {
+    "itm": "内裤",
+    "itmk": "DB",
+    "itme": 10,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "浴衣",
+    "itmk": "DB",
+    "itme": 12,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "工作装",
+    "itmk": "DB",
+    "itme": 15,
+    "itms": 8,
+    "itmsk": ""
+  },
+  {
+    "itm": "迷彩服",
+    "itmk": "DB",
+    "itme": 15,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "内裤",
+    "itmk": "DB",
+    "itme": 10,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "浴衣",
+    "itmk": "DB",
+    "itme": 12,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "工作装",
+    "itmk": "DB",
+    "itme": 15,
+    "itms": 8,
+    "itmsk": ""
+  },
+  {
+    "itm": "迷彩服",
+    "itmk": "DB",
+    "itme": 15,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "飞行头盔",
+    "itmk": "DH",
+    "itme": 40,
+    "itms": 12,
+    "itmsk": "I"
+  },
+  {
+    "itm": "防毒面具",
+    "itmk": "DH",
+    "itme": 20,
+    "itms": 15,
+    "itmsk": "q"
+  },
+  {
+    "itm": "安全帽",
+    "itmk": "DH",
+    "itme": 35,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "太阳眼镜",
+    "itmk": "DH",
+    "itme": 6,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "头巾",
+    "itmk": "DH",
+    "itme": 3,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "口罩",
+    "itmk": "DH",
+    "itme": 4,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "防灾头巾",
+    "itmk": "DH",
+    "itme": 3,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "太阳眼镜",
+    "itmk": "DH",
+    "itme": 6,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "头巾",
+    "itmk": "DH",
+    "itme": 3,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "口罩",
+    "itmk": "DH",
+    "itme": 4,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "防灾头巾",
+    "itmk": "DH",
+    "itme": 3,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "绝缘胶鞋",
+    "itmk": "DF",
+    "itme": 20,
+    "itms": 10,
+    "itmsk": "E"
+  },
+  {
+    "itm": "军靴",
+    "itmk": "DF",
+    "itme": 25,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "运动鞋",
+    "itmk": "DF",
+    "itme": 5,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "高跟鞋",
+    "itmk": "DF",
+    "itme": 5,
+    "itms": 2,
+    "itmsk": ""
+  },
+  {
+    "itm": "篮球鞋",
+    "itmk": "DF",
+    "itme": 5,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "钉鞋",
+    "itmk": "DF",
+    "itme": 10,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "运动鞋",
+    "itmk": "DF",
+    "itme": 5,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "高跟鞋",
+    "itmk": "DF",
+    "itme": 5,
+    "itms": 2,
+    "itmsk": ""
+  },
+  {
+    "itm": "篮球鞋",
+    "itmk": "DF",
+    "itme": 5,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "钉鞋",
+    "itmk": "DF",
+    "itme": 10,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "耳塞",
+    "itmk": "A",
+    "itme": 1,
+    "itms": 2,
+    "itmsk": "W"
+  },
+  {
+    "itm": "无垢的荣光",
+    "itmk": "A",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  }
+]

--- a/data/start_weapons.json
+++ b/data/start_weapons.json
@@ -1,0 +1,863 @@
+[
+  {
+    "itm": "菜刀",
+    "itmk": "WK",
+    "itme": 15,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "叉子",
+    "itmk": "WK",
+    "itme": 10,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "小刀",
+    "itmk": "WK",
+    "itme": 17,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "短刀",
+    "itmk": "WK",
+    "itme": 15,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "军用小刀",
+    "itmk": "WK",
+    "itme": 20,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "双刃小刀",
+    "itmk": "WK",
+    "itme": 20,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "镰刀",
+    "itmk": "WK",
+    "itme": 20,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "冰锥",
+    "itmk": "WK",
+    "itme": 8,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "日本刀",
+    "itmk": "WK",
+    "itme": 25,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆軍刀☆",
+    "itmk": "WK",
+    "itme": 30,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "卷筒卫生纸",
+    "itmk": "WP",
+    "itme": 1,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "笔记本电脑",
+    "itmk": "WP",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "大纸扇",
+    "itmk": "WP",
+    "itme": 4,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "衣架",
+    "itmk": "WP",
+    "itme": 6,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "大喇叭",
+    "itmk": "WP",
+    "itme": 10,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "锅盖",
+    "itmk": "WP",
+    "itme": 10,
+    "itms": 20,
+    "itmsk": ""
+  },
+  {
+    "itm": "十手",
+    "itmk": "WP",
+    "itme": 12,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "三叉",
+    "itmk": "WP",
+    "itme": 12,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "棍棒",
+    "itmk": "WP",
+    "itme": 10,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "金属棒",
+    "itmk": "WP",
+    "itme": 22,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "双截棍",
+    "itmk": "WP",
+    "itme": 18,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "手机",
+    "itmk": "WC",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "飞镖",
+    "itmk": "WC",
+    "itme": 12,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "飞镖",
+    "itmk": "WC",
+    "itme": 6,
+    "itms": 24,
+    "itmsk": ""
+  },
+  {
+    "itm": "飞镖",
+    "itmk": "WC",
+    "itme": 6,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "回力镖",
+    "itmk": "WC",
+    "itme": 9,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "高级飞镖",
+    "itmk": "WC",
+    "itme": 8,
+    "itms": 24,
+    "itmsk": ""
+  },
+  {
+    "itm": "乒乓球",
+    "itmk": "WC",
+    "itme": 3,
+    "itms": 24,
+    "itmsk": ""
+  },
+  {
+    "itm": "篮球",
+    "itmk": "WC",
+    "itme": 12,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "棒球",
+    "itmk": "WC",
+    "itme": 22,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "网球",
+    "itmk": "WC",
+    "itme": 4,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "飞镖",
+    "itmk": "WC",
+    "itme": 12,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "回力镖",
+    "itmk": "WC",
+    "itme": 9,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "高级飞镖",
+    "itmk": "WC",
+    "itme": 8,
+    "itms": 24,
+    "itmsk": ""
+  },
+  {
+    "itm": "篮球",
+    "itmk": "WC",
+    "itme": 12,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "棒球",
+    "itmk": "WC",
+    "itme": 22,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "网球",
+    "itmk": "WC",
+    "itme": 4,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "炸弹",
+    "itmk": "WD",
+    "itme": 35,
+    "itms": 3,
+    "itmsk": "d"
+  },
+  {
+    "itm": "手榴弹",
+    "itmk": "WD",
+    "itme": 40,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "照明弹",
+    "itmk": "WD",
+    "itme": 20,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "炸弹",
+    "itmk": "WD",
+    "itme": 65,
+    "itms": 3,
+    "itmsk": "d"
+  },
+  {
+    "itm": "手榴弹",
+    "itmk": "WD",
+    "itme": 40,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "照明弹",
+    "itmk": "WD",
+    "itme": 20,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "炸弹",
+    "itmk": "WD",
+    "itme": 65,
+    "itms": 3,
+    "itmsk": "d"
+  },
+  {
+    "itm": "手榴弹",
+    "itmk": "WD",
+    "itme": 40,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "照明弹",
+    "itmk": "WD",
+    "itme": 20,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "手枪",
+    "itmk": "WG",
+    "itme": 30,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "火绳枪",
+    "itmk": "WG",
+    "itme": 30,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆Sig Sauer P230 9mm☆",
+    "itmk": "WG",
+    "itme": 40,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆哥尔德357左轮手枪☆",
+    "itmk": "WG",
+    "itme": 30,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆S&W M59自动手枪☆",
+    "itmk": "WG",
+    "itme": 35,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆Colt Highway Patrolman☆",
+    "itmk": "WG",
+    "itme": 45,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆CZ．M75☆",
+    "itmk": "WG",
+    "itme": 40,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆散弹枪☆",
+    "itmk": "WG",
+    "itme": 45,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆狙击枪☆",
+    "itmk": "WG",
+    "itme": 45,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆S&W 38口径左轮枪☆",
+    "itmk": "WG",
+    "itme": 30,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆Remington 31R☆",
+    "itmk": "WG",
+    "itme": 45,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "★IMI手槍★",
+    "itmk": "WG",
+    "itme": 45,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "★Colt Highway Patrolman★",
+    "itmk": "WG",
+    "itme": 50,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "★橘纹金镶嵌火绳枪★",
+    "itmk": "WG",
+    "itme": 50,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "菜刀",
+    "itmk": "WK",
+    "itme": 15,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "叉子",
+    "itmk": "WK",
+    "itme": 10,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "小刀",
+    "itmk": "WK",
+    "itme": 17,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "短刀",
+    "itmk": "WK",
+    "itme": 15,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "军用小刀",
+    "itmk": "WK",
+    "itme": 20,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "双刃小刀",
+    "itmk": "WK",
+    "itme": 20,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "镰刀",
+    "itmk": "WK",
+    "itme": 20,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "冰锥",
+    "itmk": "WK",
+    "itme": 8,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "日本刀",
+    "itmk": "WK",
+    "itme": 25,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆軍刀☆",
+    "itmk": "WK",
+    "itme": 30,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "卷筒卫生纸",
+    "itmk": "WP",
+    "itme": 1,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "笔记本电脑",
+    "itmk": "WP",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "大纸扇",
+    "itmk": "WP",
+    "itme": 4,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "衣架",
+    "itmk": "WP",
+    "itme": 6,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "大喇叭",
+    "itmk": "WP",
+    "itme": 10,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "锅盖",
+    "itmk": "WP",
+    "itme": 10,
+    "itms": 20,
+    "itmsk": ""
+  },
+  {
+    "itm": "十手",
+    "itmk": "WP",
+    "itme": 12,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "三叉",
+    "itmk": "WP",
+    "itme": 12,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "棍棒",
+    "itmk": "WP",
+    "itme": 10,
+    "itms": 3,
+    "itmsk": ""
+  },
+  {
+    "itm": "金属棒",
+    "itmk": "WP",
+    "itme": 22,
+    "itms": 5,
+    "itmsk": ""
+  },
+  {
+    "itm": "双截棍",
+    "itmk": "WP",
+    "itme": 18,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "手机",
+    "itmk": "WC",
+    "itme": 1,
+    "itms": 1,
+    "itmsk": ""
+  },
+  {
+    "itm": "飞镖",
+    "itmk": "WC",
+    "itme": 12,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "飞镖",
+    "itmk": "WC",
+    "itme": 6,
+    "itms": 24,
+    "itmsk": ""
+  },
+  {
+    "itm": "飞镖",
+    "itmk": "WC",
+    "itme": 6,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "回力镖",
+    "itmk": "WC",
+    "itme": 9,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "高级飞镖",
+    "itmk": "WC",
+    "itme": 8,
+    "itms": 24,
+    "itmsk": ""
+  },
+  {
+    "itm": "乒乓球",
+    "itmk": "WC",
+    "itme": 3,
+    "itms": 24,
+    "itmsk": ""
+  },
+  {
+    "itm": "篮球",
+    "itmk": "WC",
+    "itme": 12,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "棒球",
+    "itmk": "WC",
+    "itme": 22,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "网球",
+    "itmk": "WC",
+    "itme": 4,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "飞镖",
+    "itmk": "WC",
+    "itme": 12,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "回力镖",
+    "itmk": "WC",
+    "itme": 9,
+    "itms": 15,
+    "itmsk": ""
+  },
+  {
+    "itm": "高级飞镖",
+    "itmk": "WC",
+    "itme": 8,
+    "itms": 24,
+    "itmsk": ""
+  },
+  {
+    "itm": "篮球",
+    "itmk": "WC",
+    "itme": 12,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "棒球",
+    "itmk": "WC",
+    "itme": 22,
+    "itms": 4,
+    "itmsk": ""
+  },
+  {
+    "itm": "网球",
+    "itmk": "WC",
+    "itme": 4,
+    "itms": 12,
+    "itmsk": ""
+  },
+  {
+    "itm": "炸弹",
+    "itmk": "WD",
+    "itme": 35,
+    "itms": 3,
+    "itmsk": "d"
+  },
+  {
+    "itm": "手榴弹",
+    "itmk": "WD",
+    "itme": 40,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "照明弹",
+    "itmk": "WD",
+    "itme": 20,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "炸弹",
+    "itmk": "WD",
+    "itme": 65,
+    "itms": 3,
+    "itmsk": "d"
+  },
+  {
+    "itm": "手榴弹",
+    "itmk": "WD",
+    "itme": 40,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "照明弹",
+    "itmk": "WD",
+    "itme": 20,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "炸弹",
+    "itmk": "WD",
+    "itme": 65,
+    "itms": 3,
+    "itmsk": "d"
+  },
+  {
+    "itm": "手榴弹",
+    "itmk": "WD",
+    "itme": 40,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "照明弹",
+    "itmk": "WD",
+    "itme": 20,
+    "itms": 5,
+    "itmsk": "d"
+  },
+  {
+    "itm": "手枪",
+    "itmk": "WG",
+    "itme": 30,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "火绳枪",
+    "itmk": "WG",
+    "itme": 30,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆Sig Sauer P230 9mm☆",
+    "itmk": "WG",
+    "itme": 40,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆哥尔德357左轮手枪☆",
+    "itmk": "WG",
+    "itme": 30,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆S&W M59自动手枪☆",
+    "itmk": "WG",
+    "itme": 35,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆Colt Highway Patrolman☆",
+    "itmk": "WG",
+    "itme": 45,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆CZ．M75☆",
+    "itmk": "WG",
+    "itme": 40,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆散弹枪☆",
+    "itmk": "WG",
+    "itme": 45,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆狙击枪☆",
+    "itmk": "WG",
+    "itme": 45,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆S&W 38口径左轮枪☆",
+    "itmk": "WG",
+    "itme": 30,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "☆Remington 31R☆",
+    "itmk": "WG",
+    "itme": 45,
+    "itms": 6,
+    "itmsk": ""
+  },
+  {
+    "itm": "退魔符",
+    "itmk": "WF",
+    "itme": 14,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "结界符",
+    "itmk": "WF",
+    "itme": 20,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "御札弹幕",
+    "itmk": "WF",
+    "itme": 25,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "退魔符",
+    "itmk": "WF",
+    "itme": 14,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "结界符",
+    "itmk": "WF",
+    "itme": 20,
+    "itms": 10,
+    "itmsk": ""
+  },
+  {
+    "itm": "御札弹幕",
+    "itmk": "WF",
+    "itme": 25,
+    "itms": 10,
+    "itmsk": ""
+  }
+]

--- a/mogoDB.md/start_items.md
+++ b/mogoDB.md/start_items.md
@@ -1,0 +1,3 @@
+# 开局物品与武器
+
+新增 `data/start_items.json` 和 `data/start_weapons.json` 两个文件用于给新玩家随机分配初始道具与武器。这些数据仅在代码中读取，不需要在 MongoDB 中建立集合或导入记录，因此无额外的数据库操作步骤。


### PR DESCRIPTION
## Summary
- parse `stitem.config.php` and `stwep.config.php` from the original repo
- save the results as `data/start_items.json` and `data/start_weapons.json`
- give new players random starting items and weapons on creation
- document that the JSON data requires no DB changes

## Testing
- `python3 - <<'EOF'
import json;print(len(json.load(open('data/start_items.json'))));print(len(json.load(open('data/start_weapons.json'))));
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6876fdd72d4c83228740a46ff051ca46