### PR TITLE
Add starter items and weapon selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ mongo ../data/initData.js
 php scripts/generateNpcData.php
 ```
 
+此外，`data` 目录还新增了 `start_items.json` 与 `start_weapons.json`，用于初始化
+玩家的开局物品与随机武器。后端会在创建角色时读取这两个文件，无需额外导入数
+据库。
+
 导入完成后即可获得与原作一致的基础游戏信息、地图区域以及默认物品池。
 如需手动添加地图或物品，可参照 `mogoDB.md/mapareas.md` 和 `mogoDB.md/mapitems.md` 的说明。
 

--- a/backend/src/services/player/entry.js
+++ b/backend/src/services/player/entry.js
@@ -3,6 +3,12 @@ const GameInfo = require('../../models/GameInfo');
 const Club = require('../../models/Club');
 const { START_THRESHOLD } = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
+const fs = require('fs');
+const path = require('path');
+
+const dataDir = path.join(__dirname, '../../../data');
+const startItems = JSON.parse(fs.readFileSync(path.join(dataDir, 'start_items.json')));
+const startWeapons = JSON.parse(fs.readFileSync(path.join(dataDir, 'start_weapons.json')));
 
 async function clubs() {
   const clubs = await Club.find({}, 'cid name');
@@ -39,6 +45,13 @@ async function enter(user, body) {
         base.money += c.money;
       }
     }
+    const weapon = startWeapons[Math.floor(Math.random() * startWeapons.length)];
+    let itemA = startItems[Math.floor(Math.random() * startItems.length)];
+    let itemB;
+    do {
+      itemB = startItems[Math.floor(Math.random() * startItems.length)];
+    } while (itemB.name === itemA.name && itemB.kind === itemA.kind);
+
     player = await Player.create({
       pid,
       uid: user._id,
@@ -51,7 +64,30 @@ async function enter(user, body) {
       att: base.att,
       def: base.def,
       money: base.money,
-      club: club || 0
+      club: club || 0,
+      wep: weapon.name,
+      wepk: weapon.kind,
+      wepe: weapon.effect,
+      weps: String(weapon.dur),
+      wepsk: weapon.skill || '',
+      itm1: '面包',
+      itmk1: 'HH',
+      itme1: 100,
+      itms1: '30',
+      itm2: '矿泉水',
+      itmk2: 'HS',
+      itme2: 100,
+      itms2: '30',
+      itm3: itemA.name,
+      itmk3: itemA.kind,
+      itme3: itemA.effect,
+      itms3: String(itemA.dur),
+      itmsk3: itemA.skill || '',
+      itm4: itemB.name,
+      itmk4: itemB.kind,
+      itme4: itemB.effect,
+      itms4: String(itemB.dur),
+      itmsk4: itemB.skill || ''
     });
     user.lastgame = gid;
     user.lastpid = pid;

--- a/data/start_items.json
+++ b/data/start_items.json
@@ -1,0 +1,632 @@
+[
+  {
+    "name": "生命探测器",
+    "kind": "ER",
+    "effect": 3,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "生命探测器",
+    "kind": "ER",
+    "effect": 3,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "生命探测器",
+    "kind": "ER",
+    "effect": 3,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "生命探测器",
+    "kind": "ER",
+    "effect": 3,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "毒药",
+    "kind": "Y",
+    "effect": 1,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "毒药",
+    "kind": "Y",
+    "effect": 1,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "毒药",
+    "kind": "Y",
+    "effect": 1,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "毒药",
+    "kind": "Y",
+    "effect": 1,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "解毒剂",
+    "kind": "Cp",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "解毒剂",
+    "kind": "Cp",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "烧伤药剂",
+    "kind": "Cu",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "解冻药水",
+    "kind": "Ci",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "麻痹药剂",
+    "kind": "Ce",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "清醒药剂",
+    "kind": "Cw",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "苹果酒",
+    "kind": "HS",
+    "effect": 50,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "鸡尾酒",
+    "kind": "HS",
+    "effect": 50,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "威士忌酒",
+    "kind": "HS",
+    "effect": 60,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "点心",
+    "kind": "HS",
+    "effect": 50,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "手机",
+    "kind": "WC",
+    "effect": 20,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "笔记本电脑",
+    "kind": "WP",
+    "effect": 20,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "手机",
+    "kind": "WC",
+    "effect": 20,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "笔记本电脑",
+    "kind": "WP",
+    "effect": 20,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "信管",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "信管",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "信管",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "导火线",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "导火线",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "导火线",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "手枪子弹",
+    "kind": "GB",
+    "effect": 1,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "手枪子弹",
+    "kind": "GB",
+    "effect": 1,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "机枪子弹",
+    "kind": "GBr",
+    "effect": 1,
+    "dur": "40",
+    "skill": ""
+  },
+  {
+    "name": "机枪子弹",
+    "kind": "GBr",
+    "effect": 1,
+    "dur": "40",
+    "skill": ""
+  },
+  {
+    "name": "压缩气罐",
+    "kind": "GBi",
+    "effect": 1,
+    "dur": "20",
+    "skill": ""
+  },
+  {
+    "name": "枪械电池",
+    "kind": "GBe",
+    "effect": 1,
+    "dur": "20",
+    "skill": ""
+  },
+  {
+    "name": "水",
+    "kind": "HS",
+    "effect": 70,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "水",
+    "kind": "HS",
+    "effect": 70,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "水",
+    "kind": "HS",
+    "effect": 70,
+    "dur": "8",
+    "skill": ""
+  },
+  {
+    "name": "水",
+    "kind": "HS",
+    "effect": 70,
+    "dur": "8",
+    "skill": ""
+  },
+  {
+    "name": "地雷",
+    "kind": "TN",
+    "effect": 300,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "地雷",
+    "kind": "TN",
+    "effect": 300,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "绳索",
+    "kind": "TN",
+    "effect": 120,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "绳索",
+    "kind": "TN",
+    "effect": 120,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "绳索",
+    "kind": "TN",
+    "effect": 120,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "绳索",
+    "kind": "TN",
+    "effect": 120,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "★阔剑地雷★",
+    "kind": "TN",
+    "effect": 450,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "★阔剑地雷★",
+    "kind": "TN",
+    "effect": 450,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "警用盾牌",
+    "kind": "DA",
+    "effect": 52,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "绝缘手套",
+    "kind": "DA",
+    "effect": 12,
+    "dur": "15",
+    "skill": "E"
+  },
+  {
+    "name": "简易盾牌",
+    "kind": "DA",
+    "effect": 35,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "皮手套",
+    "kind": "DA",
+    "effect": 15,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "手表",
+    "kind": "DA",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "手链",
+    "kind": "DA",
+    "effect": 2,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "垫肩",
+    "kind": "DA",
+    "effect": 5,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "简易盾牌",
+    "kind": "DA",
+    "effect": 35,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "皮手套",
+    "kind": "DA",
+    "effect": 15,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "手表",
+    "kind": "DA",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "手链",
+    "kind": "DA",
+    "effect": 2,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "垫肩",
+    "kind": "DA",
+    "effect": 5,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "核电站工作服",
+    "kind": "DB",
+    "effect": 45,
+    "dur": "20",
+    "skill": "U"
+  },
+  {
+    "name": "特种部队制服",
+    "kind": "DB",
+    "effect": 40,
+    "dur": "20",
+    "skill": "G"
+  },
+  {
+    "name": "内裤",
+    "kind": "DB",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "浴衣",
+    "kind": "DB",
+    "effect": 12,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "工作装",
+    "kind": "DB",
+    "effect": 15,
+    "dur": "8",
+    "skill": ""
+  },
+  {
+    "name": "迷彩服",
+    "kind": "DB",
+    "effect": 15,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "内裤",
+    "kind": "DB",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "浴衣",
+    "kind": "DB",
+    "effect": 12,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "工作装",
+    "kind": "DB",
+    "effect": 15,
+    "dur": "8",
+    "skill": ""
+  },
+  {
+    "name": "迷彩服",
+    "kind": "DB",
+    "effect": 15,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "飞行头盔",
+    "kind": "DH",
+    "effect": 40,
+    "dur": "12",
+    "skill": "I"
+  },
+  {
+    "name": "防毒面具",
+    "kind": "DH",
+    "effect": 20,
+    "dur": "15",
+    "skill": "q"
+  },
+  {
+    "name": "安全帽",
+    "kind": "DH",
+    "effect": 35,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "太阳眼镜",
+    "kind": "DH",
+    "effect": 6,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "头巾",
+    "kind": "DH",
+    "effect": 3,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "口罩",
+    "kind": "DH",
+    "effect": 4,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "防灾头巾",
+    "kind": "DH",
+    "effect": 3,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "太阳眼镜",
+    "kind": "DH",
+    "effect": 6,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "头巾",
+    "kind": "DH",
+    "effect": 3,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "口罩",
+    "kind": "DH",
+    "effect": 4,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "防灾头巾",
+    "kind": "DH",
+    "effect": 3,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "绝缘胶鞋",
+    "kind": "DF",
+    "effect": 20,
+    "dur": "10",
+    "skill": "E"
+  },
+  {
+    "name": "军靴",
+    "kind": "DF",
+    "effect": 25,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "运动鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "高跟鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "篮球鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "钉鞋",
+    "kind": "DF",
+    "effect": 10,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "运动鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "高跟鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "篮球鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "钉鞋",
+    "kind": "DF",
+    "effect": 10,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "耳塞",
+    "kind": "A",
+    "effect": 1,
+    "dur": "2",
+    "skill": "W"
+  }
+]

--- a/data/start_weapons.json
+++ b/data/start_weapons.json
@@ -1,0 +1,863 @@
+[
+  {
+    "name": "菜刀",
+    "kind": "WK",
+    "effect": 15,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "叉子",
+    "kind": "WK",
+    "effect": 10,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "小刀",
+    "kind": "WK",
+    "effect": 17,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "短刀",
+    "kind": "WK",
+    "effect": 15,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "军用小刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "双刃小刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "镰刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "冰锥",
+    "kind": "WK",
+    "effect": 8,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "日本刀",
+    "kind": "WK",
+    "effect": 25,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "☆軍刀☆",
+    "kind": "WK",
+    "effect": 30,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "卷筒卫生纸",
+    "kind": "WP",
+    "effect": 1,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "笔记本电脑",
+    "kind": "WP",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "大纸扇",
+    "kind": "WP",
+    "effect": 4,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "衣架",
+    "kind": "WP",
+    "effect": 6,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "大喇叭",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "锅盖",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "20",
+    "skill": ""
+  },
+  {
+    "name": "十手",
+    "kind": "WP",
+    "effect": 12,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "三叉",
+    "kind": "WP",
+    "effect": 12,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "棍棒",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "金属棒",
+    "kind": "WP",
+    "effect": 22,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "双截棍",
+    "kind": "WP",
+    "effect": 18,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "手机",
+    "kind": "WC",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 6,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 6,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "回力镖",
+    "kind": "WC",
+    "effect": 9,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "高级飞镖",
+    "kind": "WC",
+    "effect": 8,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "乒乓球",
+    "kind": "WC",
+    "effect": 3,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "篮球",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "棒球",
+    "kind": "WC",
+    "effect": 22,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "网球",
+    "kind": "WC",
+    "effect": 4,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "回力镖",
+    "kind": "WC",
+    "effect": 9,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "高级飞镖",
+    "kind": "WC",
+    "effect": 8,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "篮球",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "棒球",
+    "kind": "WC",
+    "effect": 22,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "网球",
+    "kind": "WC",
+    "effect": 4,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 35,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 65,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 65,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "手枪",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "火绳枪",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Sig Sauer P230 9mm☆",
+    "kind": "WG",
+    "effect": 40,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆哥尔德357左轮手枪☆",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆S&W M59自动手枪☆",
+    "kind": "WG",
+    "effect": 35,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Colt Highway Patrolman☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆CZ．M75☆",
+    "kind": "WG",
+    "effect": 40,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆散弹枪☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆狙击枪☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆S&W 38口径左轮枪☆",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Remington 31R☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "★IMI手槍★",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "★Colt Highway Patrolman★",
+    "kind": "WG",
+    "effect": 50,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "★橘纹金镶嵌火绳枪★",
+    "kind": "WG",
+    "effect": 50,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "菜刀",
+    "kind": "WK",
+    "effect": 15,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "叉子",
+    "kind": "WK",
+    "effect": 10,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "小刀",
+    "kind": "WK",
+    "effect": 17,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "短刀",
+    "kind": "WK",
+    "effect": 15,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "军用小刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "双刃小刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "镰刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "冰锥",
+    "kind": "WK",
+    "effect": 8,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "日本刀",
+    "kind": "WK",
+    "effect": 25,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "☆軍刀☆",
+    "kind": "WK",
+    "effect": 30,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "卷筒卫生纸",
+    "kind": "WP",
+    "effect": 1,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "笔记本电脑",
+    "kind": "WP",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "大纸扇",
+    "kind": "WP",
+    "effect": 4,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "衣架",
+    "kind": "WP",
+    "effect": 6,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "大喇叭",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "锅盖",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "20",
+    "skill": ""
+  },
+  {
+    "name": "十手",
+    "kind": "WP",
+    "effect": 12,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "三叉",
+    "kind": "WP",
+    "effect": 12,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "棍棒",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "金属棒",
+    "kind": "WP",
+    "effect": 22,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "双截棍",
+    "kind": "WP",
+    "effect": 18,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "手机",
+    "kind": "WC",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 6,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 6,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "回力镖",
+    "kind": "WC",
+    "effect": 9,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "高级飞镖",
+    "kind": "WC",
+    "effect": 8,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "乒乓球",
+    "kind": "WC",
+    "effect": 3,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "篮球",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "棒球",
+    "kind": "WC",
+    "effect": 22,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "网球",
+    "kind": "WC",
+    "effect": 4,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "回力镖",
+    "kind": "WC",
+    "effect": 9,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "高级飞镖",
+    "kind": "WC",
+    "effect": 8,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "篮球",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "棒球",
+    "kind": "WC",
+    "effect": 22,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "网球",
+    "kind": "WC",
+    "effect": 4,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 35,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 65,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 65,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "手枪",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "火绳枪",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Sig Sauer P230 9mm☆",
+    "kind": "WG",
+    "effect": 40,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆哥尔德357左轮手枪☆",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆S&W M59自动手枪☆",
+    "kind": "WG",
+    "effect": 35,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Colt Highway Patrolman☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆CZ．M75☆",
+    "kind": "WG",
+    "effect": 40,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆散弹枪☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆狙击枪☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆S&W 38口径左轮枪☆",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Remington 31R☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "退魔符",
+    "kind": "WF",
+    "effect": 14,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "结界符",
+    "kind": "WF",
+    "effect": 20,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "御札弹幕",
+    "kind": "WF",
+    "effect": 25,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "退魔符",
+    "kind": "WF",
+    "effect": 14,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "结界符",
+    "kind": "WF",
+    "effect": 20,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "御札弹幕",
+    "kind": "WF",
+    "effect": 25,
+    "dur": "10",
+    "skill": ""
+  }
+]


### PR DESCRIPTION
## Summary
- add JSON pools for start items and start weapons
- assign bread, water and random items/weapon when a player enters
- document new data files

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test --prefix frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_687725817ba48322a7a6b250a76dcde6