### PR TITLE
Add discard item feature

### DIFF
--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -65,3 +65,11 @@ exports.pickReplace = (req, res) => {
 exports.pickEquip = (req, res) => {
   handle(() => playerService.pickEquip(req.user, req.body), req, res);
 };
+
+exports.dropItem = (req, res) => {
+  handle(() => playerService.dropItem(req.user, req.body), req, res);
+};
+
+exports.dropEquip = (req, res) => {
+  handle(() => playerService.dropEquip(req.user, req.body), req, res);
+};

--- a/backend/src/routes/game.js
+++ b/backend/src/routes/game.js
@@ -23,5 +23,7 @@ router.post('/pickequip', auth, playerController.pickEquip);
 router.post('/use', auth, playerController.useItem);
 router.post('/equip', auth, playerController.equip);
 router.post('/unequip', auth, playerController.unequip);
+router.post('/drop', auth, playerController.dropItem);
+router.post('/dropequip', auth, playerController.dropEquip);
 
 module.exports = router;

--- a/backend/src/services/player/items.js
+++ b/backend/src/services/player/items.js
@@ -325,6 +325,91 @@ async function unequip(user, body) {
   return { msg: `卸下了${name}`, player: formatPlayer(player) };
 }
 
+async function dropItem(user, body) {
+  const { pid, index } = body;
+  const player = await Player.findOne({ pid, uid: user._id });
+  if (!player) {
+    const err = new Error('玩家不存在');
+    err.status = 404;
+    throw err;
+  }
+  if (player.hp <= 0) {
+    const err = new Error('你已经死亡');
+    err.status = 400;
+    throw err;
+  }
+  if (index < 0 || index >= 5) {
+    const err = new Error('物品编号错误');
+    err.status = 400;
+    throw err;
+  }
+  const name = player[`itm${index}`];
+  if (!name) {
+    const err = new Error('物品不存在');
+    err.status = 400;
+    throw err;
+  }
+  await dropMapItem(
+    player.pls,
+    name,
+    player[`itmk${index}`],
+    player[`itme${index}`],
+    String(player[`itms${index}`]),
+    player[`itmsk${index}`]
+  );
+  player[`itm${index}`] = '';
+  player[`itmk${index}`] = '';
+  player[`itme${index}`] = 0;
+  player[`itms${index}`] = '0';
+  player[`itmsk${index}`] = '';
+  await player.save();
+  return { msg: `丢弃了${name}`, player: formatPlayer(player) };
+}
+
+async function dropEquip(user, body) {
+  const { pid, slot } = body;
+  const allow = ['wep', 'arb', 'arh', 'ara', 'arf', 'art'];
+  const player = await Player.findOne({ pid, uid: user._id });
+  if (!player) {
+    const err = new Error('玩家不存在');
+    err.status = 404;
+    throw err;
+  }
+  if (player.hp <= 0) {
+    const err = new Error('你已经死亡');
+    err.status = 400;
+    throw err;
+  }
+  if (!allow.includes(slot)) {
+    const err = new Error('装备栏错误');
+    err.status = 400;
+    throw err;
+  }
+  const name = player[slot];
+  if (!name) {
+    const err = new Error('没有装备');
+    err.status = 400;
+    throw err;
+  }
+
+  await dropMapItem(
+    player.pls,
+    player[slot],
+    player[`${slot}k`],
+    player[`${slot}e`],
+    String(player[`${slot}s`]),
+    player[`${slot}sk`]
+  );
+
+  player[slot] = '';
+  player[`${slot}k`] = '';
+  player[`${slot}e`] = 0;
+  player[`${slot}s`] = '0';
+  player[`${slot}sk`] = '';
+  await player.save();
+  return { msg: `丢弃了${name}`, player: formatPlayer(player) };
+}
+
 async function pickReplace(user, body) {
   const { pid, itemId, index } = body;
   const player = await Player.findOne({ pid, uid: user._id });
@@ -455,5 +540,7 @@ module.exports = {
   equip,
   unequip,
   pickReplace,
-  pickEquip
+  pickEquip,
+  dropItem,
+  dropEquip
 };

--- a/frontend/src/api/game.js
+++ b/frontend/src/api/game.js
@@ -21,3 +21,5 @@ export const pickEquip = (pid, itemId) =>
 export const useItem = (pid, index) => api.post('/game/use', { pid, index })
 export const equipItem = (pid, index) => api.post('/game/equip', { pid, index })
 export const unequipItem = (pid, slot) => api.post('/game/unequip', { pid, slot })
+export const dropItem = (pid, index) => api.post('/game/drop', { pid, index })
+export const dropEquip = (pid, slot) => api.post('/game/dropequip', { pid, slot })

--- a/frontend/src/components/EquipmentList.vue
+++ b/frontend/src/components/EquipmentList.vue
@@ -6,9 +6,10 @@
       <el-table-column prop="attr" label="属性" width="80" />
       <el-table-column prop="effect" label="效果" width="80" />
       <el-table-column prop="dur" label="耐久" width="80" />
-      <el-table-column label="操作" width="80">
+      <el-table-column label="操作" width="120">
         <template #default="{ row }">
           <el-button size="small" @click="$emit('unequip', row.field)" :disabled="!row.name">卸下</el-button>
+          <el-button size="small" @click="$emit('drop', row.field)" :disabled="!row.name">丢弃</el-button>
         </template>
       </el-table-column>
     </el-table>
@@ -19,7 +20,7 @@
 defineProps({
   rows: Array
 })
-defineEmits(['unequip'])
+defineEmits(['unequip','drop'])
 </script>
 
 <style scoped>

--- a/frontend/src/components/Inventory.vue
+++ b/frontend/src/components/Inventory.vue
@@ -16,6 +16,7 @@
           <template #default="scope">
             <el-button size="small" @click="equip(scope.$index)" :disabled="scope.row.disableEquip">装备</el-button>
             <el-button size="small" @click="useIt(scope.$index)" :disabled="scope.row.disableUse">使用</el-button>
+            <el-button size="small" @click="drop(scope.$index)" :disabled="!scope.row.name">丢弃</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -27,7 +28,7 @@
 import { computed } from 'vue'
 import { playerInfo as info } from '../store/player'
 import { playerId } from '../store/user'
-import { equipItem, useItem } from '../api'
+import { equipItem, useItem, dropItem } from '../api'
 
 const props = defineProps({
   modelValue: Boolean
@@ -93,6 +94,16 @@ function useIt(index) {
   }).catch(e => {
     const msg = e.response?.data?.msg
     alert(msg || '使用失败')
+  })
+}
+
+function drop(index) {
+  if (!playerId.value) return
+  dropItem(playerId.value, index).then(({ data }) => {
+    info.value = data.player
+  }).catch(e => {
+    const msg = e.response?.data?.msg
+    alert(msg || '丢弃失败')
   })
 }
 </script>

--- a/frontend/src/components/InventoryPanel.vue
+++ b/frontend/src/components/InventoryPanel.vue
@@ -11,6 +11,7 @@
           <template #default="scope">
             <el-button size="small" @click="equip(scope.$index)" :disabled="scope.row.disableEquip">装备</el-button>
             <el-button size="small" @click="useIt(scope.$index)" :disabled="scope.row.disableUse">使用</el-button>
+            <el-button size="small" @click="drop(scope.$index)" :disabled="!scope.row.name">丢弃</el-button>
           </template>
         </el-table-column>
       </el-table>
@@ -22,7 +23,7 @@
 import { computed } from 'vue'
 import { playerInfo as info } from '../store/player'
 import { playerId } from '../store/user'
-import { equipItem, useItem } from '../api'
+import { equipItem, useItem, dropItem } from '../api'
 
 function getType(kind) {
   if (!kind) return ''
@@ -79,6 +80,16 @@ function useIt(index) {
   }).catch(e => {
     const msg = e.response?.data?.msg
     alert(msg || '使用失败')
+  })
+}
+
+function drop(index) {
+  if (!playerId.value) return
+  dropItem(playerId.value, index).then(({ data }) => {
+    info.value = data.player
+  }).catch(e => {
+    const msg = e.response?.data?.msg
+    alert(msg || '丢弃失败')
   })
 }
 </script>

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -5,7 +5,7 @@
       <!-- 左侧区域 -->
       <div class="left-panel">
         <PlayerStats v-if="info" :info="info" :injuries="injuries" />
-        <EquipmentList v-if="info" :rows="equipRows" @unequip="unequip" />
+        <EquipmentList v-if="info" :rows="equipRows" @unequip="unequip" @drop="dropEquipItem" />
         <LogPanel :logs="logs" />
       </div>
 
@@ -64,7 +64,7 @@ import EquipmentList from '../components/EquipmentList.vue'
 import LogPanel from '../components/LogPanel.vue'
 import ActionBar from '../components/ActionBar.vue'
 import SearchDialog from '../components/SearchDialog.vue'
-import { move, search, getStatus, getMapAreas, rest, pickItem, pickReplace, pickEquip, unequipItem } from '../api'
+import { move, search, getStatus, getMapAreas, rest, pickItem, pickReplace, pickEquip, unequipItem, dropEquip } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo as info } from '../store/player'
 import { mapAreas as places } from '../store/map'
@@ -228,6 +228,18 @@ async function unequip(field) {
     addLog(data.msg)
   } catch (e) {
     alert(e.response?.data?.msg || '卸下失败')
+  }
+}
+
+async function dropEquipItem(field) {
+  if (!playerId.value) return
+  stopRestTimer()
+  try {
+    const { data } = await dropEquip(playerId.value, field)
+    info.value = data.player
+    addLog(data.msg)
+  } catch (e) {
+    alert(e.response?.data?.msg || '丢弃失败')
   }
 }
 


### PR DESCRIPTION
## Summary
- allow players to drop inventory or equipped items
- expose new backend routes `/game/drop` and `/game/dropequip`
- add API wrappers and buttons in the UI to discard items

## Testing
- `npm test` (backend – expected failure: no test specified)
- `npm test` (frontend – missing script)

------
https://chatgpt.com/codex/tasks/task_e_6877404c0ff48322ab9d386b031e3ee1