### PR TITLE
Load NPCs on game start

### DIFF
--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -79,6 +79,17 @@ async function startGame() {
     console.error('清理旧玩家数据失败', e);
   }
 
+  try {
+    const npcFile = path.join(__dirname, '../../../data/npcs.json');
+    const npcs = JSON.parse(fs.readFileSync(npcFile));
+    await Player.deleteMany({ type: { $gt: 0 } });
+    if (npcs && npcs.length) {
+      await Player.insertMany(npcs);
+    }
+  } catch (e) {
+    console.error('初始化 NPC 失败', e);
+  }
+
   const areas = await MapArea.find({}, 'pid');
   const ids = areas.map(a => a.pid);
   for (const id of ids) {

--- a/mogoDB.md/npcs.md
+++ b/mogoDB.md/npcs.md
@@ -1,11 +1,13 @@
 # NPC 数据导入
 
-原版 `npc.data.config.php` 中定义了各类 NPC。本项目将其转换为 `data/npcs.json`，
-格式与 `backend/src/models/Player.js` 一致。可通过以下命令导入：
+原版 `npc.data.config.php` 中定义了各类 NPC。本项目已将其转换为 `data/npcs.json`，
+格式与 `backend/src/models/Player.js` 一致。可通过以下命令手动导入：
 
 ```bash
+use dts
+db.players.deleteMany({ type: { $gt: 0 } })
 mongoimport --db dts --collection players --file ../data/npcs.json --jsonArray
 ```
 
-该操作会把 `type>0` 的玩家数据替换为默认 NPC 列表，游戏开始时也会自动从该文件
-写入 NPC。
+上述命令会清空旧的 NPC 数据后重新写入默认列表。系统在启动新游戏时同样会自
+动执行清理并从 `data/npcs.json` 导入 NPC，一般无需手动操作。


### PR DESCRIPTION
## Summary
- import NPC records when starting a game
- document NPC MongoDB import steps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687743ed21048322b4fa1217d54bdee5