### PR TITLE
Implement starter items for new players

### DIFF
--- a/backend/src/services/player/entry.js
+++ b/backend/src/services/player/entry.js
@@ -1,6 +1,8 @@
 const Player = require('../../models/Player');
 const GameInfo = require('../../models/GameInfo');
 const Club = require('../../models/Club');
+const fs = require('fs');
+const path = require('path');
 const { START_THRESHOLD } = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
 
@@ -53,9 +55,62 @@ async function enter(user, body) {
       money: base.money,
       club: club || 0
     });
+
+    try {
+      const itemFile = path.join(__dirname, '../../../data/start_items.json');
+      const wepFile = path.join(__dirname, '../../../data/start_weapons.json');
+      const startItems = JSON.parse(fs.readFileSync(itemFile));
+      const startWeps = JSON.parse(fs.readFileSync(wepFile));
+
+      const pick = arr => arr[Math.floor(Math.random() * arr.length)];
+
+      player.itm1 = '面包';
+      player.itmk1 = 'HH';
+      player.itme1 = 100;
+      player.itms1 = '30';
+      player.itmsk1 = '';
+
+      player.itm2 = '矿泉水';
+      player.itmk2 = 'HS';
+      player.itme2 = 100;
+      player.itms2 = '30';
+      player.itmsk2 = '';
+
+      if (startWeps.length) {
+        const w = pick(startWeps);
+        player.wep = w.name;
+        player.wepk = w.kind;
+        player.wepe = Number(w.effect);
+        player.weps = String(w.dur);
+        player.wepsk = w.skill;
+      }
+
+      if (startItems.length) {
+        const it1 = pick(startItems);
+        player.itm3 = it1.name;
+        player.itmk3 = it1.kind;
+        player.itme3 = Number(it1.effect);
+        player.itms3 = String(it1.dur);
+        player.itmsk3 = it1.skill;
+
+        let it2;
+        do {
+          it2 = pick(startItems);
+        } while (startItems.length > 1 && it2.kind === it1.kind);
+        player.itm4 = it2.name;
+        player.itmk4 = it2.kind;
+        player.itme4 = Number(it2.effect);
+        player.itms4 = String(it2.dur);
+        player.itmsk4 = it2.skill;
+      }
+    } catch (e) {
+      console.error('初始化玩家物品失败', e);
+    }
+
     user.lastgame = gid;
     user.lastpid = pid;
     await user.save();
+    await player.save();
   }
 
   return { pid: player.pid, pls: player.pls };


### PR DESCRIPTION
## Summary
- add fs and path modules
- after creating a player, assign random weapons and items from `data/start_items.json` and `data/start_weapons.json`
- set bread and water as default consumables

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687743f3069c8322a829df776f16e7c9