### PR TITLE
Add danger zone controls in admin UI

### DIFF
--- a/backend/src/controllers/gameController.js
+++ b/backend/src/controllers/gameController.js
@@ -5,6 +5,7 @@ const gameService = require('../services/gameService');
 exports.getInfo = async (req, res) => {
   try {
     await gameService.checkDangerAreas();
+    await gameService.checkGameOver();
     const info = await GameInfo.findOne();
     if (info) {
       const [validnum, alivenum, deathnum] = await Promise.all([

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const auth = require('../middlewares/auth');
 const checkAdmin = require('../middlewares/admin');
 const fieldsMeta = require('../fieldsMeta');
+const gameService = require('../services/gameService');
 
 const models = {
   players: require('../models/Player'),
@@ -44,6 +45,28 @@ router.get('/maps', async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: '获取失败' });
+  }
+});
+
+router.post('/mapareas/:pid/open', async (req, res) => {
+  const pid = Number(req.params.pid);
+  try {
+    await gameService.openArea(pid);
+    res.json({ msg: '已开启禁区' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '操作失败' });
+  }
+});
+
+router.post('/mapareas/:pid/close', async (req, res) => {
+  const pid = Number(req.params.pid);
+  try {
+    await gameService.closeArea(pid);
+    res.json({ msg: '已关闭禁区' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '操作失败' });
   }
 });
 

--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -174,10 +174,39 @@ async function checkDangerAreas() {
   }
 }
 
+async function checkGameOver() {
+  const info = await GameInfo.findOne();
+  if (!info || info.gamestate < START_THRESHOLD) return;
+  const alive = await Player.countDocuments({ type: 0, hp: { $gt: 0 } });
+  if (alive > 0) return;
+  await stopGame();
+}
+
+async function openArea(pid) {
+  await MapArea.updateOne({ pid }, { danger: 1 });
+  const info = await GameInfo.findOne();
+  if (info) {
+    info.areanum = await MapArea.countDocuments({ danger: 1 });
+    await info.save();
+  }
+}
+
+async function closeArea(pid) {
+  await MapArea.updateOne({ pid }, { danger: 0 });
+  const info = await GameInfo.findOne();
+  if (info) {
+    info.areanum = await MapArea.countDocuments({ danger: 1 });
+    await info.save();
+  }
+}
+
 module.exports = {
   ensureDefaultClubs,
   startGame,
   stopGame,
   mapAreas,
-  checkDangerAreas
+  checkDangerAreas,
+  checkGameOver,
+  openArea,
+  closeArea
 };

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -6,3 +6,5 @@ export const adminUpdate = (col, id, data) => api.put(`/admin/${col}/${id}`, dat
 export const adminDelete = (col, id) => api.delete(`/admin/${col}/${id}`)
 export const adminFieldMeta = col => api.get(`/admin/${col}/fieldmeta`)
 export const adminMaps = () => api.get('/admin/maps')
+export const adminOpenArea = pid => api.post(`/admin/mapareas/${pid}/open`)
+export const adminCloseArea = pid => api.post(`/admin/mapareas/${pid}/close`)

--- a/frontend/src/components/TablePanel.vue
+++ b/frontend/src/components/TablePanel.vue
@@ -14,7 +14,13 @@
         <el-button v-if="!isMaps" size="small" text @click="$emit('edit', row, f)">编辑</el-button>
       </template>
     </el-table-column>
-    <el-table-column v-if="!isMaps" label="操作" width="120">
+    <el-table-column v-if="isMapAreas" label="禁区操作" width="140">
+      <template #default="{ row }">
+        <el-button v-if="row.danger" size="small" type="warning" @click="$emit('close', row)">关闭</el-button>
+        <el-button v-else size="small" type="primary" @click="$emit('open', row)">开启</el-button>
+      </template>
+    </el-table-column>
+    <el-table-column v-if="!isMaps && !isMapAreas" label="操作" width="120">
       <template #default="{ row }">
         <el-button size="small" type="danger" @click="$emit('remove', row)">删除</el-button>
       </template>
@@ -27,10 +33,11 @@ const props = defineProps({
   items: Array,
   fieldMeta: Array,
   isMaps: Boolean,
+  isMapAreas: Boolean,
   loading: Boolean,
   mapAreas: Array
 })
-const emit = defineEmits(['load-more','edit','remove'])
+const emit = defineEmits(['load-more','edit','remove','open','close'])
 function handleLoadMore(){
   emit('load-more')
 }

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -18,11 +18,14 @@
       :items="items"
       :field-meta="fieldMeta"
       :is-maps="isMaps"
+      :is-map-areas="isMapAreas"
       :loading="loading"
       :map-areas="mapAreas"
       @load-more="loadMore"
       @edit="openFieldEdit"
       @remove="remove"
+      @open="openArea"
+      @close="closeArea"
     />
     <FormDialog
       v-model="fieldDialogVisible"
@@ -54,7 +57,9 @@ import {
   adminDelete,
   adminFieldMeta,
   adminMaps,
-  getMapAreas
+  getMapAreas,
+  adminOpenArea,
+  adminCloseArea
 } from '../api'
 import { mapAreas } from '../store/map'
 
@@ -90,6 +95,7 @@ const editForm = ref({})
 const createDialogVisible = ref(false)
 const createData = ref({})
 const isMaps = computed(() => collection.value === 'maps')
+const isMapAreas = computed(() => collection.value === 'mapareas')
 const areaFilter = ref(-1)
 
 watch(collection, () => {
@@ -232,6 +238,24 @@ async function remove(row) {
     fetchItems()
   } catch (e) {
     alert(e.response?.data?.msg || '删除失败')
+  }
+}
+
+async function openArea(row) {
+  try {
+    await adminOpenArea(row.pid)
+    row.danger = 1
+  } catch (e) {
+    alert(e.response?.data?.msg || '操作失败')
+  }
+}
+
+async function closeArea(row) {
+  try {
+    await adminCloseArea(row.pid)
+    row.danger = 0
+  } catch (e) {
+    alert(e.response?.data?.msg || '操作失败')
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- allow admin to open/close danger zones via new endpoints
- automatically stop game when no players alive
- expose admin API methods for map area control
- support danger zone toggle buttons in admin map area list

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in frontend *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688047e3bfb48322bda3dafca29b44a3