### PR TITLE
Fix NPC kill gameover

### DIFF
--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -78,6 +78,7 @@ const replaceVisible = ref(false)
 let replaceItemId = null
 let programmatic = false
 let restTimer = null
+let statusTimer = null
 const enemy = ref(null)
 
 async function refreshMapAreas() {
@@ -209,7 +210,15 @@ async function fetchStatus() {
     setTarget(data.pls)
     checkDeath()
     return data
-  } catch {
+  } catch (e) {
+    if (e.response?.data?.msg === '你已经死亡') {
+      try {
+        const res = await getDeadStatus(playerId.value)
+        info.value = res.data
+        router.replace('/gameover')
+        return
+      } catch {}
+    }
     info.value = null
   }
 }
@@ -218,10 +227,15 @@ onMounted(() => {
   refreshMapAreas()
   if (info.value) setTarget(info.value.pls)
   else fetchStatus()
+  statusTimer = setInterval(fetchStatus, 5000)
 })
 
 onUnmounted(() => {
   stopRestTimer()
+  if (statusTimer) {
+    clearInterval(statusTimer)
+    statusTimer = null
+  }
 })
 
 async function unequip(field) {


### PR DESCRIPTION
## Summary
- detect death when status API returns error
- poll status periodically

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688049e236608322884c2de20f50d3c3