### PR TITLE
Fix early stop when no players

### DIFF
--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -177,8 +177,12 @@ async function checkDangerAreas() {
 async function checkGameOver() {
   const info = await GameInfo.findOne();
   if (!info || info.gamestate < START_THRESHOLD) return;
-  const alive = await Player.countDocuments({ type: 0, hp: { $gt: 0 } });
-  if (alive > 0) return;
+  const [alive, valid] = await Promise.all([
+    Player.countDocuments({ type: 0, hp: { $gt: 0 } }),
+    Player.countDocuments({ type: 0 })
+  ]);
+  // 尚无人进入游戏时不结束，避免刚开局就关闭
+  if (valid === 0 || alive > 0) return;
   await stopGame();
 }
 


### PR DESCRIPTION
## Summary
- avoid ending game immediately if no players have joined

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68804e1302888322810074df3282f309