### PR TITLE
修复初始装备读取及死亡状态

### DIFF
--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -195,7 +195,7 @@ async function deadStatus(user, query) {
     err.status = 404;
     throw err;
   }
-  return player;
+  return formatPlayer(player);
 }
 
 async function list(user) {

--- a/backend/src/services/player/entry.js
+++ b/backend/src/services/player/entry.js
@@ -57,8 +57,15 @@ async function enter(user, body) {
     });
 
     try {
-      const itemFile = path.join(__dirname, '../../../data/start_items.json');
-      const wepFile = path.join(__dirname, '../../../data/start_weapons.json');
+      // 数据目录位于项目根目录的 /data，需从当前文件向上返回四级
+      const itemFile = path.join(
+        __dirname,
+        '../../../../data/start_items.json'
+      );
+      const wepFile = path.join(
+        __dirname,
+        '../../../../data/start_weapons.json'
+      );
       const startItems = JSON.parse(fs.readFileSync(itemFile));
       const startWeps = JSON.parse(fs.readFileSync(wepFile));
 


### PR DESCRIPTION
## Summary
- 修正读取起始装备时的路径，正确指向根目录 `data`
- `deadStatus` 接口返回格式化后的玩家信息

## Testing
- `npm test` (后端，无测试用例)
- `npm test` (前端，脚本不存在)

------
https://chatgpt.com/codex/tasks/task_e_68805061eb088322adc4186b86e7a60b