### PR TITLE
Add battle panel

### DIFF
--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -141,7 +141,7 @@ async function search(user, body) {
         log += `你发现了玩家【${enemy.name}】！<br>`;
       }
       await player.save();
-      return { log, player: formatPlayer(player), enemy: { pid: enemy.pid, name: enemy.name, type: enemy.type } };
+      return { log, player: formatPlayer(player), enemy: { pid: enemy.pid, name: enemy.name, type: enemy.type, lvl: enemy.lvl, hp: enemy.hp, mhp: enemy.mhp, wep: enemy.wep, wepe: enemy.wepe } };
     }
   }
 

--- a/backend/src/services/player/fight.js
+++ b/backend/src/services/player/fight.js
@@ -149,7 +149,7 @@ async function attack(user, body){
     { toid: enemy.pid, type: 'b', time, log }
   ]);
 
-  return { log, player: formatPlayer(player), enemy: { pid: enemy.pid, hp: enemy.hp, name: enemy.name, type: enemy.type } };
+  return { log, player: formatPlayer(player), enemy: { pid: enemy.pid, hp: enemy.hp, mhp: enemy.mhp, name: enemy.name, type: enemy.type, lvl: enemy.lvl, wep: enemy.wep, wepe: enemy.wepe } };
 }
 
 module.exports = { attack };

--- a/frontend/src/components/BattlePanel.vue
+++ b/frontend/src/components/BattlePanel.vue
@@ -1,0 +1,54 @@
+<template>
+  <el-card class="card-section card-no-title" v-if="enemy && player">
+    <div class="battle-panel">
+      <div class="side">
+        <p>{{ player.name }}</p>
+        <p>等级：{{ player.lvl }}</p>
+        <p>生命：{{ player.hp }}/{{ player.mhp }}</p>
+        <p>武器：{{ player.wep || '无' }}</p>
+        <p>武器攻击：{{ player.wepe || 0 }}</p>
+      </div>
+      <div class="side">
+        <p>{{ enemy.type > 0 ? 'NPC' : '玩家' }}：{{ enemy.name }}</p>
+        <p>等级：{{ enemy.lvl ?? '?' }}</p>
+        <p>生命：{{ enemyHpLabel }}</p>
+        <p>武器：{{ enemy.wep || '未知' }}</p>
+        <p>武器攻击：{{ enemy.wepe ?? 0 }}</p>
+      </div>
+    </div>
+  </el-card>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+const props = defineProps({
+  player: Object,
+  enemy: Object
+})
+const enemyHpLabel = computed(() => {
+  if (!props.enemy || props.enemy.mhp === undefined) return '?' 
+  const ratio = props.enemy.mhp ? props.enemy.hp / props.enemy.mhp : 0
+  if (ratio > 0.88) return '近满'
+  if (ratio > 0.66) return '约七成'
+  if (ratio > 0.44) return '约半血'
+  if (ratio > 0.22) return '不足半血'
+  if (ratio > 0.1) return '濒危'
+  return '濒死'
+})
+</script>
+
+<style scoped>
+.battle-panel {
+  display: flex;
+  justify-content: space-between;
+}
+.side {
+  flex: 1;
+}
+.card-section {
+  margin-bottom: 20px;
+}
+:deep(.card-no-title .el-card__header) {
+  display: none;
+}
+</style>

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -5,6 +5,7 @@
       <!-- 左侧区域 -->
       <div class="left-panel">
         <PlayerStats v-if="info" :info="info" :injuries="injuries" />
+        <BattlePanel v-if="enemy" :player="info" :enemy="enemy" />
         <EquipmentList v-if="info" :rows="equipRows" @unequip="unequip" @drop="dropEquipItem" />
         <LogPanel :logs="logs" />
       </div>
@@ -61,6 +62,7 @@ import { useRouter } from 'vue-router'
 import InventoryPanel from '../components/InventoryPanel.vue'
 import PlayerStats from '../components/PlayerStats.vue'
 import EquipmentList from '../components/EquipmentList.vue'
+import BattlePanel from '../components/BattlePanel.vue'
 import LogPanel from '../components/LogPanel.vue'
 import ActionBar from '../components/ActionBar.vue'
 import SearchDialog from '../components/SearchDialog.vue'


### PR DESCRIPTION
## Summary
- show enemy and player battle info when encountering a target
- include extra enemy details from backend search/attack

## Testing
- `npm --prefix backend test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688088dcf9888322b57ecfa157977958