### PR TITLE
Implement encounter memory and escape action

### DIFF
--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -1,5 +1,9 @@
 module.exports = {
   START_THRESHOLD: 20,
   AREA_INTERVAL: 20 * 60,
-  AREA_ADD: 2
+  AREA_ADD: 2,
+  WEATHER_ACTIVE_OBBS: [
+    10, 20, 0, -5, -10, -20, -15, 0, -7,
+    -10, -10, -5, 0, -5, -20, -5, 0, 20
+  ]
 };

--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -70,6 +70,10 @@ exports.attack = (req, res) => {
   handle(() => playerService.attack(req.user, req.body), req, res);
 };
 
+exports.escape = (req, res) => {
+  handle(() => playerService.escape(req.user, req.body), req, res);
+};
+
 exports.dropItem = (req, res) => {
   handle(() => playerService.dropItem(req.user, req.body), req, res);
 };

--- a/backend/src/models/Player.js
+++ b/backend/src/models/Player.js
@@ -119,6 +119,7 @@ const playerSchema = new mongoose.Schema({
   itms6: { type: String, default: '0' },
   itmsk6: { type: String, default: '' },
   restStart: { type: Number, default: 0 },
+  enemymemory: { type: String, default: '' },
   searchmemory: { type: String, default: '' },
   nskill: { type: String, default: '' },
   nskillpara: { type: String, default: '' }

--- a/backend/src/routes/game.js
+++ b/backend/src/routes/game.js
@@ -24,6 +24,7 @@ router.post('/use', auth, playerController.useItem);
 router.post('/equip', auth, playerController.equip);
 router.post('/unequip', auth, playerController.unequip);
 router.post('/attack', auth, playerController.attack);
+router.post('/escape', auth, playerController.escape);
 router.post('/drop', auth, playerController.dropItem);
 router.post('/dropequip', auth, playerController.dropEquip);
 

--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -3,7 +3,7 @@ const GameInfo = require('../../models/GameInfo');
 const MapArea = require('../../models/MapArea');
 const MapItem = require('../../models/MapItem');
 const MapTrap = require('../../models/MapTrap');
-const { START_THRESHOLD } = require('../../config/constants');
+const { START_THRESHOLD, WEATHER_ACTIVE_OBBS } = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
 // 引入完整的工具模块，防止部分函数因解构失败而未定义
 const playerUtils = require('./utils');
@@ -12,6 +12,7 @@ const { formatPlayer } = playerUtils;
 
 async function exploreScene(player, pid) {
   let log = '';
+  player.enemymemory = '';
 
   // 1. 特殊地图事件
   if (player.pls === 7 && Math.random() < 0.5) {
@@ -44,32 +45,33 @@ async function exploreScene(player, pid) {
   const enemies = await Player.find({ pls: player.pls, hp: { $gt: 0 }, pid: { $ne: pid } });
   if (enemies.length) {
     const enemy = enemies[Math.floor(Math.random() * enemies.length)];
-    let chance = 0.5 + (player.sp - enemy.sp) / 200;
-    if (enemy.type > 0) chance -= 0.05;
+    const info = await GameInfo.findOne();
+    const weatherMod = info ? (WEATHER_ACTIVE_OBBS[info.weather] || 0) / 100 : 0;
+    let base = enemy.type > 0 ? 0.55 : 0.5;
+    let chance = base + (player.sp - enemy.sp) / 200 + weatherMod;
     if (chance < 0.05) chance = 0.05;
     if (chance > 0.95) chance = 0.95;
-    if (Math.random() < chance) {
-      if (enemy.type > 0) {
-        if (enemy.sp > player.sp) {
-          const dmg = Math.floor(Math.random() * 10) + 1;
-          player.hp = Math.max(player.hp - dmg, 0);
-          log += `NPC【${enemy.name}】的伏击使你受到${dmg}点伤害！<br>`;
-          if (player.hp <= 0) {
-            player.state = 27;
-            log += '你遭到致命打击！<br>';
-          }
-        } else {
-          log += `你发现了NPC【${enemy.name}】，可以选择攻击。<br>`;
-        }
-      } else {
-        log += `你发现了玩家【${enemy.name}】！<br>`;
-      }
+    const playerFirst = Math.random() < chance;
+    if (playerFirst) {
+      log += enemy.type > 0 ? `你发现了NPC【${enemy.name}】，可以选择攻击。<br>` : `你发现了玩家【${enemy.name}】！<br>`;
+      player.enemymemory = JSON.stringify({ id: enemy.pid, initiator: true });
       await player.save();
       return {
         log,
         player: formatPlayer(player),
         enemy: { pid: enemy.pid, name: enemy.name, type: enemy.type, lvl: enemy.lvl, hp: enemy.hp, mhp: enemy.mhp, wep: enemy.wep, wepe: enemy.wepe }
       };
+    } else {
+      const dmg = Math.floor(Math.random() * 10) + 1;
+      player.hp = Math.max(player.hp - dmg, 0);
+      log += `${enemy.type>0?'NPC':'玩家'}【${enemy.name}】的先制攻击使你受到${dmg}点伤害！<br>`;
+      if (player.hp <= 0) {
+        player.state = 27;
+        log += '你遭到致命打击！<br>';
+      }
+      player.enemymemory = JSON.stringify({ id: enemy.pid, initiator: false });
+      await player.save();
+      return { log, player: formatPlayer(player) };
     }
   }
 

--- a/backend/src/services/player/fight.js
+++ b/backend/src/services/player/fight.js
@@ -111,6 +111,12 @@ async function attack(user, body){
     err.status = 400;
     throw err;
   }
+  const memory = player.enemymemory ? JSON.parse(player.enemymemory) : null;
+  if(!memory || memory.id !== eid){
+    const err = new Error('当前没有与该目标交战');
+    err.status = 400;
+    throw err;
+  }
   await restoreMemoryItem(player);
   applyRest(player);
   const cost = 20;
@@ -141,15 +147,54 @@ async function attack(user, body){
     }
   }
 
-  await Promise.all([enemy.save(), player.save()]);
-
   const time = Math.floor(Date.now()/1000);
   await Log.create([
     { toid: player.pid, type: 'b', time, log },
     { toid: enemy.pid, type: 'b', time, log }
   ]);
-
+  player.enemymemory = '';
+  enemy.enemymemory = '';
+  await Promise.all([player.save(), enemy.save()]);
   return { log, player: formatPlayer(player), enemy: { pid: enemy.pid, hp: enemy.hp, mhp: enemy.mhp, name: enemy.name, type: enemy.type, lvl: enemy.lvl, wep: enemy.wep, wepe: enemy.wepe } };
 }
 
-module.exports = { attack };
+async function escape(user, body){
+  const { pid } = body;
+  await checkDangerAreas();
+  const info = await GameInfo.findOne();
+  if(!info || info.gamestate < START_THRESHOLD){
+    const err = new Error('游戏未开始');
+    err.status = 400;
+    throw err;
+  }
+  const player = await Player.findOne({ pid, uid: user._id });
+  if(!player){
+    const err = new Error('玩家不存在');
+    err.status = 404;
+    throw err;
+  }
+  if(player.hp <= 0){
+    const err = new Error('你已经死亡');
+    err.status = 400;
+    throw err;
+  }
+  const memory = player.enemymemory ? JSON.parse(player.enemymemory) : null;
+  if(!memory){
+    const err = new Error('没有遭遇敌人');
+    err.status = 400;
+    throw err;
+  }
+  if(!memory.initiator){
+    const err = new Error('无法逃跑');
+    err.status = 400;
+    throw err;
+  }
+  player.enemymemory = '';
+  await player.save();
+  const time = Math.floor(Date.now()/1000);
+  const log = '你选择逃跑，成功回避了战斗。';
+  await Log.create([{ toid: player.pid, type: 'b', time, log }]);
+  return { log, player: formatPlayer(player) };
+}
+
+module.exports = { attack, escape };

--- a/mogoDB.md/players.md
+++ b/mogoDB.md/players.md
@@ -20,8 +20,22 @@ db.players.updateMany(
 use dts;
 db.players.updateMany(
   { restStart: { $exists: false } },
-  { $set: { restStart: 0 } }
+ { $set: { restStart: 0 } }
 )
 ```
 
-该字段对应 `backend/src/models/Player.js` 中的 `restStart`。 
+该字段对应 `backend/src/models/Player.js` 中的 `restStart`。
+
+## 新增 enemymemory 字段
+
+为在遭遇战中记录敌人信息，需要在 `players` 集合新增 `enemymemory` 字段，类型为 `String`。
+
+```javascript
+use dts;
+db.players.updateMany(
+  { enemymemory: { $exists: false } },
+  { $set: { enemymemory: '' } }
+)
+```
+
+该字段对应 `backend/src/models/Player.js` 中的 `enemymemory`。


### PR DESCRIPTION
## Summary
- track last encountered enemy in `Player` via `enemymemory`
- adjust encounter logic with weather modifiers and escape capability
- add `/escape` API and related controller handling
- document MongoDB update for new field

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6880972560488322bf956e7b7e2ace2f