### PR TITLE
Add club proficiency bonuses

### DIFF
--- a/backend/src/config/clubProficiency.js
+++ b/backend/src/config/clubProficiency.js
@@ -1,0 +1,12 @@
+module.exports = {
+  1: { start: { wp: 25 }, level: { wp: [4, 6] } }, // 街头霸王
+  2: { start: { wk: 25 }, level: { wk: [4, 6] } }, // 见敌必斩
+  3: { start: { wg: 25 }, level: { wg: [4, 6] } }, // 狙击鹰眼
+  4: { start: { wc: 25 }, level: { wc: [4, 6] } }, // 灌篮高手
+  5: { start: { wd: 25 }, level: { wd: [5, 7] } }, // 拆弹专家
+  9: { start: { wf: 20 }, level: { wf: [3, 5] } }, // 超能力者
+  10: { extra: 'fastGrowth' }, // 高速成长
+  13: { hpAddStart: 200, hpGain: [5, 7] }, // 根性兄贵
+  14: { attDefStart: 200, levelAttDef: 2 }, // 肌肉兄贵
+  18: { startAll: 5, startSkillPoints: 5, evenLevelSkillPoint: 1, crossBonus: 0.25 }
+};

--- a/backend/src/services/player/entry.js
+++ b/backend/src/services/player/entry.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const { START_THRESHOLD } = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
+const clubPro = require('../../config/clubProficiency');
 
 async function clubs() {
   const clubs = await Club.find({}, 'cid name');
@@ -55,6 +56,34 @@ async function enter(user, body) {
       money: base.money,
       club: club || 0
     });
+
+    const prof = clubPro[player.club];
+    if (prof) {
+      if (prof.startAll) {
+        player.wp = prof.startAll + (player.wp || 0);
+        player.wk = prof.startAll + (player.wk || 0);
+        player.wg = prof.startAll + (player.wg || 0);
+        player.wc = prof.startAll + (player.wc || 0);
+        player.wd = prof.startAll + (player.wd || 0);
+        player.wf = prof.startAll + (player.wf || 0);
+      }
+      if (prof.start) {
+        for (const k in prof.start) {
+          player[k] = (player[k] || 0) + prof.start[k];
+        }
+      }
+      if (prof.startSkillPoints) {
+        player.skillpoint = (player.skillpoint || 0) + prof.startSkillPoints;
+      }
+      if (prof.attDefStart) {
+        player.att += prof.attDefStart;
+        player.def += prof.attDefStart;
+      }
+      if (prof.hpAddStart) {
+        player.hp += prof.hpAddStart;
+        player.mhp += prof.hpAddStart;
+      }
+    }
 
     try {
       // 数据目录位于项目根目录的 /data，需从当前文件向上返回四级

--- a/backend/src/services/player/fight.js
+++ b/backend/src/services/player/fight.js
@@ -3,6 +3,7 @@ const GameInfo = require('../../models/GameInfo');
 const Log = require('../../models/Log');
 const { START_THRESHOLD } = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
+const clubPro = require('../../config/clubProficiency');
 // 引入完整工具避免解构失败
 const playerUtils = require('./utils');
 const { applyRest, restoreMemoryItem, formatPlayer } = playerUtils;
@@ -106,7 +107,17 @@ function getWeaponKind(wepk){
 function getSkill(attacker){
   const kind = getWeaponKind(attacker.wepk);
   const field = SKILL_FIELDS[kind];
-  return field ? Number(attacker[field] || 0) : 0;
+  let val = field ? Number(attacker[field] || 0) : 0;
+  if(field && attacker.club === 18){
+    const others = ['wp','wk','wg','wc','wd','wf'].filter(f=>f!==field);
+    let sum = 0;
+    for(const f of others){ sum += Number(attacker[f]||0); }
+    const conf = clubPro[18];
+    if(conf && conf.crossBonus){
+      val += Math.floor(sum * conf.crossBonus);
+    }
+  }
+  return val;
 }
 
 function gainSkill(attacker, amount = 1){
@@ -114,6 +125,14 @@ function gainSkill(attacker, amount = 1){
   const field = SKILL_FIELDS[kind];
   if(field){
     attacker[field] = Number(attacker[field] || 0) + amount;
+    if(attacker.club === 10 && clubPro[10]){
+      if(Math.random() < 2/3){
+        attacker[field] += 1;
+      }
+      if(Math.random() < 2/3){
+        attacker.exp = (attacker.exp || 0) + 1;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- implement `clubProficiency` config listing starting skill and bonus info
- apply club-specific starting skill bonuses when creating a player
- adjust skill gain and calculation for Fast Growth and Talent titles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6880a043a4288322a37a1ea65cb3b242