### PR TITLE
Fix game service start failure

### DIFF
--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -1,6 +1,12 @@
 const constantsService = require('../services/constantsService');
 
+// 提供读取常量的统一接口，兼容通过 constants.get('KEY') 的调用方式
+function get(key) {
+  return constantsService.get(key);
+}
+
 module.exports = {
+  get,
   get START_THRESHOLD() { return constantsService.get('START_THRESHOLD'); },
   get AREA_INTERVAL() { return constantsService.get('AREA_INTERVAL'); },
   get AREA_ADD() { return constantsService.get('AREA_ADD'); },


### PR DESCRIPTION
## Summary
- add a `get` method to `constants` so services using `constants.get` work

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6880a823cd248322a394005243e6b4a2