### PR TITLE
Handle token expiration via Element Plus dialog

### DIFF
--- a/backend/src/middlewares/auth.js
+++ b/backend/src/middlewares/auth.js
@@ -15,6 +15,10 @@ module.exports = async function(req, res, next) {
     next();
   } catch (err) {
     console.error(err);
-    res.status(401).json({ msg: '无效令牌' });
+    if (err.name === 'TokenExpiredError') {
+      res.status(401).json({ msg: '令牌过期' });
+    } else {
+      res.status(401).json({ msg: '无效令牌' });
+    }
   }
 };

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,5 +1,7 @@
 import axios from 'axios'
-import { token } from '../store/user'
+import { ElMessageBox } from 'element-plus'
+import router from '../router'
+import { user, token, refreshToken, playerId } from '../store/user'
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api'
@@ -11,5 +13,33 @@ api.interceptors.request.use(config => {
   }
   return config
 })
+
+let showingExpired = false
+
+api.interceptors.response.use(
+  response => response,
+  async error => {
+    const msg = error.response?.data?.msg
+    if (error.response?.status === 401 && msg === '令牌过期' && !showingExpired) {
+      showingExpired = true
+      await ElMessageBox.alert('登录已过期，请重新登录', '提示', {
+        confirmButtonText: '返回主页',
+        callback: () => {
+          user.value = ''
+          token.value = ''
+          refreshToken.value = ''
+          playerId.value = ''
+          localStorage.removeItem('user')
+          localStorage.removeItem('token')
+          localStorage.removeItem('refreshToken')
+          localStorage.removeItem('playerId')
+          router.push('/')
+          showingExpired = false
+        }
+      })
+    }
+    return Promise.reject(error)
+  }
+)
 
 export default api


### PR DESCRIPTION
## Summary
- detect expired JWTs in backend middleware
- intercept 401 responses on the frontend and show an Element Plus alert

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` in `frontend` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882d217485483229676eafcc0e481a4