### PR TITLE
Improve trap editing display

### DIFF
--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -5,7 +5,12 @@
         <el-input v-if="f.type==='text'" v-model="form[f.name]" />
         <el-input-number v-else-if="f.type==='number'" v-model="form[f.name]" />
         <el-select v-else-if="f.type==='select'" v-model="form[f.name]">
-          <el-option v-for="op in f.options" :key="op" :label="op" :value="op" />
+          <el-option
+            v-for="op in f.options"
+            :key="typeof op === 'object' ? op.value : op"
+            :label="typeof op === 'object' ? op.label : op"
+            :value="typeof op === 'object' ? op.value : op"
+          />
         </el-select>
         <el-input v-else v-model="form[f.name]" />
       </el-form-item>

--- a/frontend/src/components/TablePanel.vue
+++ b/frontend/src/components/TablePanel.vue
@@ -30,7 +30,7 @@
 
 <script setup>
 import { stateInfo } from '../constants/death'
-import { gameStateText, chatTypeText } from '../constants/enums'
+import { gameStateText, chatTypeText, itemTypeText, trapTypeText } from '../constants/enums'
 const props = defineProps({
   items: Array,
   fieldMeta: Array,
@@ -56,6 +56,9 @@ function formatField(row, name){
   }
   if(name==='type'){
     return chatTypeText[row[name]] || row[name]
+  }
+  if(name==='itmk'){
+    return trapTypeText[row[name]] || itemTypeText[row[name]] || row[name]
   }
   if(name==='danger'){
     return row[name] ? '禁区' : '安全'

--- a/frontend/src/constants/enums.js
+++ b/frontend/src/constants/enums.js
@@ -43,3 +43,9 @@ export const itemTypeText = {
   WC: '投掷兵器',
   WN: '空手'
 }
+
+export const trapTypeText = {
+  TO: '已布设陷阱',
+  TN: '可拾取陷阱',
+  TNc: '奇迹雷'
+}

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -62,6 +62,7 @@ import {
   adminCloseArea
 } from '../api'
 import { mapAreas } from '../store/map'
+import { trapTypeText } from '../constants/enums'
 
 const collections = [
   { label: '玩家', value: 'players' },
@@ -117,8 +118,25 @@ watch(areaFilter, () => {
 async function fetchFieldMeta() {
   if (!collection.value) return
   try {
+    if ((collection.value === 'maptraps' || collection.value === 'mapitems' || collection.value === 'players') && !mapAreas.value.length) {
+      try {
+        const res = await getMapAreas()
+        mapAreas.value = res.data
+      } catch {}
+    }
     const { data } = await adminFieldMeta(collection.value)
-    fieldMeta.value = data
+    fieldMeta.value = data.map(f => {
+      const nf = { ...f }
+      if ((nf.name === 'pls' || nf.name === 'area') && mapAreas.value.length) {
+        nf.type = 'select'
+        nf.options = mapAreas.value.map((n, i) => ({ label: n, value: i }))
+      }
+      if (collection.value === 'maptraps' && nf.name === 'itmk') {
+        nf.type = 'select'
+        nf.options = Object.entries(trapTypeText).map(([k, v]) => ({ label: v, value: k }))
+      }
+      return nf
+    })
   } catch (e) {
     fieldMeta.value = []
   }
@@ -148,6 +166,17 @@ async function fetchItems(append = false) {
         const res = await getMapAreas()
         mapAreas.value = res.data
       } catch {}
+    } else if (collection.value === 'maptraps') {
+      if (!mapAreas.value.length) {
+        try {
+          const res = await getMapAreas()
+          mapAreas.value = res.data
+        } catch {}
+      }
+      const { data } = await adminList('maptraps', { skip: skip.value, limit })
+      items.value = append ? items.value.concat(data) : data
+      if (data.length < limit) allLoaded.value = true
+      skip.value += data.length
     } else if (collection.value === 'mapitems') {
       if (!mapAreas.value.length) {
         try {
@@ -188,7 +217,16 @@ function loadMore() {
 
 function openFieldEdit(row, field) {
   editRowId.value = row._id
-  editField.value = field
+  const f = { ...field }
+  if ((f.name === 'pls' || f.name === 'area') && mapAreas.value.length) {
+    f.type = 'select'
+    f.options = mapAreas.value.map((n, i) => ({ label: n, value: i }))
+  }
+  if (collection.value === 'maptraps' && f.name === 'itmk') {
+    f.type = 'select'
+    f.options = Object.entries(trapTypeText).map(([k, v]) => ({ label: v, value: k }))
+  }
+  editField.value = f
   editForm.value = { [field.name]: row[field.name] }
   fieldDialogVisible.value = true
 }


### PR DESCRIPTION
## Summary
- support trap type text values
- show trap type names in table panel
- handle select options with objects in form dialog
- display trap type and area names in admin views

## Testing
- `npm test --silent --prefix backend` *(fails: Error: no test specified)*
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6882d2947ea0832296d06d01d211645d