### PR TITLE
Improve Player Stats UI

### DIFF
--- a/frontend/src/components/PlayerStats.vue
+++ b/frontend/src/components/PlayerStats.vue
@@ -1,20 +1,44 @@
 <template>
-  <el-card class="card-section card-no-title" v-if="info">
-    <p>玩家名：{{ info.name }}</p>
-    <p>攻击力：{{ info.att }}</p>
-    <p>防御力：{{ info.def }}</p>
-    <p>等级：{{ info.lvl }}</p>
-    <p>经验值：{{ info.exp }}</p>
+  <el-card class="card-section card-no-title player-stats" v-if="info">
+    <p>{{ info.name }}　Lv.{{ info.lvl }}　EXP: {{ info.exp }}</p>
+    <p>
+      攻击力：{{ info.att }}　防御力：{{ info.def }}　
+      <el-tooltip :content="fullProfText" placement="top">
+        <span class="prof">熟练度：{{ highestProfText }}</span>
+      </el-tooltip>
+    </p>
     <p>金钱：{{ info.money }}</p>
-    <p>熟练度：殴{{ info.wp }} 斩{{ info.wk }} 射{{ info.wg }} 投{{ info.wc }} 爆{{ info.wd }} 灵{{ info.wf }}</p>
-    <p>受伤：{{ injuries }}</p>
+    <p v-if="injuries && injuries !== '无'">受伤：{{ injuries }}</p>
   </el-card>
 </template>
 
 <script setup>
-defineProps({
+import { computed } from 'vue'
+
+const props = defineProps({
   info: Object,
   injuries: String
+})
+
+const fullProfText = computed(() => {
+  if (!props.info) return ''
+  return `殴${props.info.wp} 斩${props.info.wk} 射${props.info.wg} 投${props.info.wc} 爆${props.info.wd} 灵${props.info.wf}`
+})
+
+const highestProfText = computed(() => {
+  if (!props.info) return ''
+  const fields = ['wp', 'wk', 'wg', 'wc', 'wd', 'wf']
+  const labels = ['殴', '斩', '射', '投', '爆', '灵']
+  let max = 0
+  let idx = 0
+  fields.forEach((f, i) => {
+    const val = props.info[f] || 0
+    if (val > max) {
+      max = val
+      idx = i
+    }
+  })
+  return `${labels[idx]}${max}`
 })
 </script>
 
@@ -24,5 +48,9 @@ defineProps({
 }
 :deep(.card-no-title .el-card__header) {
   display: none;
+}
+.player-stats p {
+  margin: 4px 0;
+  text-align: left;
 }
 </style>


### PR DESCRIPTION
## Summary
- adjust PlayerStats component layout
- show only highest proficiency and reveal all on hover
- hide injury line if uninjured

## Testing
- `npm install`
- `npx vite build`

------
https://chatgpt.com/codex/tasks/task_e_6882d6ec44dc83229d9f02cc2150e745