### PR TITLE
Fix admin missing NPC category

### DIFF
--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -66,6 +66,7 @@ import { trapTypeText } from '../constants/enums'
 
 const collections = [
   { label: '玩家', value: 'players' },
+  { label: 'NPC', value: 'npcs' },
   { label: '商店物品', value: 'shopitems' },
   { label: '日志', value: 'logs' },
   { label: '聊天', value: 'chats' },


### PR DESCRIPTION
## Summary
- add NPC category to admin collections

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6882da2b06dc8322ace2177217cc351b