### PR TITLE
Add items management module

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,13 @@ npm run dev
 
 ### 4. 数据初始化
 
-项目根目录 `data` 目录内提供了原作同款的 `gameinfo.json` 与 `shopitems.json` 数据文件，可直接导入 MongoDB：
+项目根目录 `data` 目录内提供了原作同款的 `gameinfo.json`、`shopitems.json` 与 `items.json` 数据文件，可直接导入 MongoDB：
 
 ```bash
 cd mogoDB.md
 mongoimport --db dts --collection gameinfos --file ../data/gameinfo.json --jsonArray
 mongoimport --db dts --collection shopitems --file ../data/shopitems.json --jsonArray
+mongoimport --db dts --collection items --file ../data/items.json --jsonArray
 mongoimport --db dts --collection mapareas --file ../data/mapareas.json --jsonArray
 mongoimport --db dts --collection mapitems --file ../data/mapitems.json --jsonArray
 ```
@@ -139,7 +140,7 @@ mongo ../data/initData.js
 ```
 
 导入完成后即可获得与原作一致的基础游戏信息、地图区域以及默认物品池。
-如需手动添加地图或物品，可参照 `mogoDB.md/mapareas.md` 和 `mogoDB.md/mapitems.md` 的说明。
+如需手动添加地图或物品，可参照 `mogoDB.md/mapareas.md`、`mogoDB.md/mapitems.md` 和 `mogoDB.md/items.md` 的说明。
 
 ---
 

--- a/backend/src/fieldsMeta.js
+++ b/backend/src/fieldsMeta.js
@@ -32,6 +32,13 @@ module.exports = {
     { name: 'price', label: '价格', type: 'number' },
     { name: 'area', label: '地区', type: 'number' }
   ],
+  items: [
+    { name: 'name', label: '名称', type: 'text' },
+    { name: 'kind', label: '种类', type: 'text' },
+    { name: 'effect', label: '效果值', type: 'number' },
+    { name: 'dur', label: '耐久/数量', type: 'text' },
+    { name: 'skill', label: '属性', type: 'text' }
+  ],
   users: [
     { name: 'username', label: '用户名', type: 'text' },
     { name: 'role', label: '角色', type: 'select', options: ['user','admin'] }

--- a/backend/src/models/Item.js
+++ b/backend/src/models/Item.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const itemSchema = new mongoose.Schema({
+  name: { type: String, default: '' },
+  kind: { type: String, default: '' },
+  effect: { type: Number, default: 0 },
+  dur: { type: String, default: '0' },
+  skill: { type: String, default: '' }
+});
+
+module.exports = mongoose.model('Item', itemSchema);

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -9,6 +9,7 @@ const models = {
   players: require('../models/Player'),
   npcs: require('../models/Player'),
   shopitems: require('../models/ShopItem'),
+  items: require('../models/Item'),
   logs: require('../models/Log'),
   chats: require('../models/Chat'),
   mapitems: require('../models/MapItem'),
@@ -93,6 +94,9 @@ router.get('/:collection', async (req, res) => {
     }
     if (req.params.collection === 'npcs') {
       filter.type = { $gt: 0 };
+    }
+    if (req.params.collection === 'items' && req.query.kind) {
+      filter.kind = req.query.kind;
     }
     const skip = Number(req.query.skip) || 0;
     const limit = Number(req.query.limit) || 100;

--- a/backend/src/services/player/entry.js
+++ b/backend/src/services/player/entry.js
@@ -1,8 +1,7 @@
 const Player = require('../../models/Player');
 const GameInfo = require('../../models/GameInfo');
 const Club = require('../../models/Club');
-const fs = require('fs');
-const path = require('path');
+const Item = require('../../models/Item');
 const constants = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
 const clubPro = require('../../config/clubProficiency');
@@ -86,17 +85,8 @@ async function enter(user, body) {
     }
 
     try {
-      // 数据目录位于项目根目录的 /data，需从当前文件向上返回四级
-      const itemFile = path.join(
-        __dirname,
-        '../../../../data/start_items.json'
-      );
-      const wepFile = path.join(
-        __dirname,
-        '../../../../data/start_weapons.json'
-      );
-      const startItems = JSON.parse(fs.readFileSync(itemFile));
-      const startWeps = JSON.parse(fs.readFileSync(wepFile));
+      const startItems = await Item.find({ kind: { $not: /^W/ } });
+      const startWeps = await Item.find({ kind: /^W/ });
 
       const pick = arr => arr[Math.floor(Math.random() * arr.length)];
 

--- a/data/initData.js
+++ b/data/initData.js
@@ -16,6 +16,13 @@ if (shopitems.length) {
   db.shopitems.insertMany(shopitems);
 }
 
+// 导入 items
+var items = JSON.parse(cat('./items.json'));
+if (items.length) {
+  db.items.remove({});
+  db.items.insertMany(items);
+}
+
 // 导入 mapareas
 var mapareas = JSON.parse(cat('./mapareas.json'));
 if (mapareas.length) {

--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,1493 @@
+[
+  {
+    "name": "生命探测器",
+    "kind": "ER",
+    "effect": 3,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "生命探测器",
+    "kind": "ER",
+    "effect": 3,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "生命探测器",
+    "kind": "ER",
+    "effect": 3,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "生命探测器",
+    "kind": "ER",
+    "effect": 3,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "毒药",
+    "kind": "Y",
+    "effect": 1,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "毒药",
+    "kind": "Y",
+    "effect": 1,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "毒药",
+    "kind": "Y",
+    "effect": 1,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "毒药",
+    "kind": "Y",
+    "effect": 1,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "解毒剂",
+    "kind": "Cp",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "解毒剂",
+    "kind": "Cp",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "烧伤药剂",
+    "kind": "Cu",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "解冻药水",
+    "kind": "Ci",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "麻痹药剂",
+    "kind": "Ce",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "清醒药剂",
+    "kind": "Cw",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "苹果酒",
+    "kind": "HS",
+    "effect": 50,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "鸡尾酒",
+    "kind": "HS",
+    "effect": 50,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "威士忌酒",
+    "kind": "HS",
+    "effect": 60,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "点心",
+    "kind": "HS",
+    "effect": 50,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "手机",
+    "kind": "WC",
+    "effect": 20,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "笔记本电脑",
+    "kind": "WP",
+    "effect": 20,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "手机",
+    "kind": "WC",
+    "effect": 20,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "笔记本电脑",
+    "kind": "WP",
+    "effect": 20,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "信管",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "信管",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "信管",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "导火线",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "导火线",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "导火线",
+    "kind": "X",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "手枪子弹",
+    "kind": "GB",
+    "effect": 1,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "手枪子弹",
+    "kind": "GB",
+    "effect": 1,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "机枪子弹",
+    "kind": "GBr",
+    "effect": 1,
+    "dur": "40",
+    "skill": ""
+  },
+  {
+    "name": "机枪子弹",
+    "kind": "GBr",
+    "effect": 1,
+    "dur": "40",
+    "skill": ""
+  },
+  {
+    "name": "压缩气罐",
+    "kind": "GBi",
+    "effect": 1,
+    "dur": "20",
+    "skill": ""
+  },
+  {
+    "name": "枪械电池",
+    "kind": "GBe",
+    "effect": 1,
+    "dur": "20",
+    "skill": ""
+  },
+  {
+    "name": "水",
+    "kind": "HS",
+    "effect": 70,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "水",
+    "kind": "HS",
+    "effect": 70,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "水",
+    "kind": "HS",
+    "effect": 70,
+    "dur": "8",
+    "skill": ""
+  },
+  {
+    "name": "水",
+    "kind": "HS",
+    "effect": 70,
+    "dur": "8",
+    "skill": ""
+  },
+  {
+    "name": "地雷",
+    "kind": "TN",
+    "effect": 300,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "地雷",
+    "kind": "TN",
+    "effect": 300,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "绳索",
+    "kind": "TN",
+    "effect": 120,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "绳索",
+    "kind": "TN",
+    "effect": 120,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "绳索",
+    "kind": "TN",
+    "effect": 120,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "绳索",
+    "kind": "TN",
+    "effect": 120,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "★阔剑地雷★",
+    "kind": "TN",
+    "effect": 450,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "★阔剑地雷★",
+    "kind": "TN",
+    "effect": 450,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "警用盾牌",
+    "kind": "DA",
+    "effect": 52,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "绝缘手套",
+    "kind": "DA",
+    "effect": 12,
+    "dur": "15",
+    "skill": "E"
+  },
+  {
+    "name": "简易盾牌",
+    "kind": "DA",
+    "effect": 35,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "皮手套",
+    "kind": "DA",
+    "effect": 15,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "手表",
+    "kind": "DA",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "手链",
+    "kind": "DA",
+    "effect": 2,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "垫肩",
+    "kind": "DA",
+    "effect": 5,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "简易盾牌",
+    "kind": "DA",
+    "effect": 35,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "皮手套",
+    "kind": "DA",
+    "effect": 15,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "手表",
+    "kind": "DA",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "手链",
+    "kind": "DA",
+    "effect": 2,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "垫肩",
+    "kind": "DA",
+    "effect": 5,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "核电站工作服",
+    "kind": "DB",
+    "effect": 45,
+    "dur": "20",
+    "skill": "U"
+  },
+  {
+    "name": "特种部队制服",
+    "kind": "DB",
+    "effect": 40,
+    "dur": "20",
+    "skill": "G"
+  },
+  {
+    "name": "内裤",
+    "kind": "DB",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "浴衣",
+    "kind": "DB",
+    "effect": 12,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "工作装",
+    "kind": "DB",
+    "effect": 15,
+    "dur": "8",
+    "skill": ""
+  },
+  {
+    "name": "迷彩服",
+    "kind": "DB",
+    "effect": 15,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "内裤",
+    "kind": "DB",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "浴衣",
+    "kind": "DB",
+    "effect": 12,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "工作装",
+    "kind": "DB",
+    "effect": 15,
+    "dur": "8",
+    "skill": ""
+  },
+  {
+    "name": "迷彩服",
+    "kind": "DB",
+    "effect": 15,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "飞行头盔",
+    "kind": "DH",
+    "effect": 40,
+    "dur": "12",
+    "skill": "I"
+  },
+  {
+    "name": "防毒面具",
+    "kind": "DH",
+    "effect": 20,
+    "dur": "15",
+    "skill": "q"
+  },
+  {
+    "name": "安全帽",
+    "kind": "DH",
+    "effect": 35,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "太阳眼镜",
+    "kind": "DH",
+    "effect": 6,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "头巾",
+    "kind": "DH",
+    "effect": 3,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "口罩",
+    "kind": "DH",
+    "effect": 4,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "防灾头巾",
+    "kind": "DH",
+    "effect": 3,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "太阳眼镜",
+    "kind": "DH",
+    "effect": 6,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "头巾",
+    "kind": "DH",
+    "effect": 3,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "口罩",
+    "kind": "DH",
+    "effect": 4,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "防灾头巾",
+    "kind": "DH",
+    "effect": 3,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "绝缘胶鞋",
+    "kind": "DF",
+    "effect": 20,
+    "dur": "10",
+    "skill": "E"
+  },
+  {
+    "name": "军靴",
+    "kind": "DF",
+    "effect": 25,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "运动鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "高跟鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "篮球鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "钉鞋",
+    "kind": "DF",
+    "effect": 10,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "运动鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "高跟鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "2",
+    "skill": ""
+  },
+  {
+    "name": "篮球鞋",
+    "kind": "DF",
+    "effect": 5,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "钉鞋",
+    "kind": "DF",
+    "effect": 10,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "耳塞",
+    "kind": "A",
+    "effect": 1,
+    "dur": "2",
+    "skill": "W"
+  },
+  {
+    "name": "菜刀",
+    "kind": "WK",
+    "effect": 15,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "叉子",
+    "kind": "WK",
+    "effect": 10,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "小刀",
+    "kind": "WK",
+    "effect": 17,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "短刀",
+    "kind": "WK",
+    "effect": 15,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "军用小刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "双刃小刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "镰刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "冰锥",
+    "kind": "WK",
+    "effect": 8,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "日本刀",
+    "kind": "WK",
+    "effect": 25,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "☆軍刀☆",
+    "kind": "WK",
+    "effect": 30,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "卷筒卫生纸",
+    "kind": "WP",
+    "effect": 1,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "笔记本电脑",
+    "kind": "WP",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "大纸扇",
+    "kind": "WP",
+    "effect": 4,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "衣架",
+    "kind": "WP",
+    "effect": 6,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "大喇叭",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "锅盖",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "20",
+    "skill": ""
+  },
+  {
+    "name": "十手",
+    "kind": "WP",
+    "effect": 12,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "三叉",
+    "kind": "WP",
+    "effect": 12,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "棍棒",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "金属棒",
+    "kind": "WP",
+    "effect": 22,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "双截棍",
+    "kind": "WP",
+    "effect": 18,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "手机",
+    "kind": "WC",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 6,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 6,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "回力镖",
+    "kind": "WC",
+    "effect": 9,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "高级飞镖",
+    "kind": "WC",
+    "effect": 8,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "乒乓球",
+    "kind": "WC",
+    "effect": 3,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "篮球",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "棒球",
+    "kind": "WC",
+    "effect": 22,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "网球",
+    "kind": "WC",
+    "effect": 4,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "回力镖",
+    "kind": "WC",
+    "effect": 9,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "高级飞镖",
+    "kind": "WC",
+    "effect": 8,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "篮球",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "棒球",
+    "kind": "WC",
+    "effect": 22,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "网球",
+    "kind": "WC",
+    "effect": 4,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 35,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 65,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 65,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "手枪",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "火绳枪",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Sig Sauer P230 9mm☆",
+    "kind": "WG",
+    "effect": 40,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆哥尔德357左轮手枪☆",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆S&W M59自动手枪☆",
+    "kind": "WG",
+    "effect": 35,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Colt Highway Patrolman☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆CZ．M75☆",
+    "kind": "WG",
+    "effect": 40,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆散弹枪☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆狙击枪☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆S&W 38口径左轮枪☆",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Remington 31R☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "★IMI手槍★",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "★Colt Highway Patrolman★",
+    "kind": "WG",
+    "effect": 50,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "★橘纹金镶嵌火绳枪★",
+    "kind": "WG",
+    "effect": 50,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "菜刀",
+    "kind": "WK",
+    "effect": 15,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "叉子",
+    "kind": "WK",
+    "effect": 10,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "小刀",
+    "kind": "WK",
+    "effect": 17,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "短刀",
+    "kind": "WK",
+    "effect": 15,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "军用小刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "双刃小刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "镰刀",
+    "kind": "WK",
+    "effect": 20,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "冰锥",
+    "kind": "WK",
+    "effect": 8,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "日本刀",
+    "kind": "WK",
+    "effect": 25,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "☆軍刀☆",
+    "kind": "WK",
+    "effect": 30,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "卷筒卫生纸",
+    "kind": "WP",
+    "effect": 1,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "笔记本电脑",
+    "kind": "WP",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "大纸扇",
+    "kind": "WP",
+    "effect": 4,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "衣架",
+    "kind": "WP",
+    "effect": 6,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "大喇叭",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "锅盖",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "20",
+    "skill": ""
+  },
+  {
+    "name": "十手",
+    "kind": "WP",
+    "effect": 12,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "三叉",
+    "kind": "WP",
+    "effect": 12,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "棍棒",
+    "kind": "WP",
+    "effect": 10,
+    "dur": "3",
+    "skill": ""
+  },
+  {
+    "name": "金属棒",
+    "kind": "WP",
+    "effect": 22,
+    "dur": "5",
+    "skill": ""
+  },
+  {
+    "name": "双截棍",
+    "kind": "WP",
+    "effect": 18,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "手机",
+    "kind": "WC",
+    "effect": 1,
+    "dur": "1",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 6,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 6,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "回力镖",
+    "kind": "WC",
+    "effect": 9,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "高级飞镖",
+    "kind": "WC",
+    "effect": 8,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "乒乓球",
+    "kind": "WC",
+    "effect": 3,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "篮球",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "棒球",
+    "kind": "WC",
+    "effect": 22,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "网球",
+    "kind": "WC",
+    "effect": 4,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "飞镖",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "回力镖",
+    "kind": "WC",
+    "effect": 9,
+    "dur": "15",
+    "skill": ""
+  },
+  {
+    "name": "高级飞镖",
+    "kind": "WC",
+    "effect": 8,
+    "dur": "24",
+    "skill": ""
+  },
+  {
+    "name": "篮球",
+    "kind": "WC",
+    "effect": 12,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "棒球",
+    "kind": "WC",
+    "effect": 22,
+    "dur": "4",
+    "skill": ""
+  },
+  {
+    "name": "网球",
+    "kind": "WC",
+    "effect": 4,
+    "dur": "12",
+    "skill": ""
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 35,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 65,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "炸弹",
+    "kind": "WD",
+    "effect": 65,
+    "dur": "3",
+    "skill": "d"
+  },
+  {
+    "name": "手榴弹",
+    "kind": "WD",
+    "effect": 40,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "照明弹",
+    "kind": "WD",
+    "effect": 20,
+    "dur": "5",
+    "skill": "d"
+  },
+  {
+    "name": "手枪",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "火绳枪",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Sig Sauer P230 9mm☆",
+    "kind": "WG",
+    "effect": 40,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆哥尔德357左轮手枪☆",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆S&W M59自动手枪☆",
+    "kind": "WG",
+    "effect": 35,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Colt Highway Patrolman☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆CZ．M75☆",
+    "kind": "WG",
+    "effect": 40,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆散弹枪☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆狙击枪☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆S&W 38口径左轮枪☆",
+    "kind": "WG",
+    "effect": 30,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "☆Remington 31R☆",
+    "kind": "WG",
+    "effect": 45,
+    "dur": "6",
+    "skill": ""
+  },
+  {
+    "name": "退魔符",
+    "kind": "WF",
+    "effect": 14,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "结界符",
+    "kind": "WF",
+    "effect": 20,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "御札弹幕",
+    "kind": "WF",
+    "effect": 25,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "退魔符",
+    "kind": "WF",
+    "effect": 14,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "结界符",
+    "kind": "WF",
+    "effect": 20,
+    "dur": "10",
+    "skill": ""
+  },
+  {
+    "name": "御札弹幕",
+    "kind": "WF",
+    "effect": 25,
+    "dur": "10",
+    "skill": ""
+  }
+]

--- a/frontend/src/pages/ItemAdmin.vue
+++ b/frontend/src/pages/ItemAdmin.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="page">
+    <h2>物品管理</h2>
+    <el-segmented v-model="currentKind" :options="kindOptions" style="margin-bottom:10px" />
+    <el-button type="primary" size="small" @click="openCreate" style="margin-left:10px">新建</el-button>
+    <el-table :data="items" style="margin-top:10px" @row-click="openEdit">
+      <el-table-column prop="name" label="名称" />
+      <el-table-column prop="kind" label="种类" width="80" />
+      <el-table-column prop="effect" label="效果值" width="80" />
+      <el-table-column prop="dur" label="耐久/数量" width="100" />
+      <el-table-column prop="skill" label="属性" />
+      <el-table-column label="操作" width="120">
+        <template #default="{ row }">
+          <el-button size="small" type="danger" @click.stop="remove(row)">删除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+    <FormDialog
+      v-model="dialogVisible"
+      :title="dialogTitle"
+      :fields="fields"
+      :form="formData"
+      @save="save"
+      @close="dialogVisible=false"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { adminList, adminCreate, adminUpdate, adminDelete } from '../api'
+import FormDialog from '../components/FormDialog.vue'
+
+const items = ref([])
+const kindOptions = ref([])
+const currentKind = ref('')
+const dialogVisible = ref(false)
+const dialogTitle = ref('')
+const formData = ref({})
+const editId = ref('')
+
+const fields = [
+  { name: 'name', label: '名称', type: 'text' },
+  { name: 'kind', label: '种类', type: 'text' },
+  { name: 'effect', label: '效果值', type: 'number' },
+  { name: 'dur', label: '耐久/数量', type: 'text' },
+  { name: 'skill', label: '属性', type: 'text' }
+]
+
+watch(currentKind, fetchItems, { immediate: true })
+
+async function fetchItems() {
+  try {
+    const { data } = await adminList('items', { kind: currentKind.value })
+    items.value = data
+    if (!kindOptions.value.length) {
+      const { data: all } = await adminList('items', { skip: 0, limit: 1000 })
+      const kinds = Array.from(new Set(all.map(i => i.kind)))
+      kindOptions.value = kinds.map(k => ({ label: k, value: k }))
+      if (!currentKind.value && kinds.length) currentKind.value = kinds[0]
+    }
+  } catch (e) {
+    alert(e.response?.data?.msg || '加载失败')
+  }
+}
+
+function openEdit(row) {
+  editId.value = row._id
+  dialogTitle.value = '编辑 ' + row.name
+  formData.value = { ...row }
+  dialogVisible.value = true
+}
+
+function openCreate() {
+  dialogTitle.value = '新建'
+  formData.value = { name: '', kind: currentKind.value, effect: 0, dur: '1', skill: '' }
+  editId.value = ''
+  dialogVisible.value = true
+}
+
+async function save() {
+  try {
+    if (editId.value) {
+      await adminUpdate('items', editId.value, formData.value)
+    } else {
+      await adminCreate('items', formData.value)
+    }
+    dialogVisible.value = false
+    fetchItems()
+  } catch (e) {
+    alert(e.response?.data?.msg || '保存失败')
+  }
+}
+
+async function remove(row) {
+  if (!confirm('确定删除？')) return
+  try {
+    await adminDelete('items', row._id)
+    fetchItems()
+  } catch (e) {
+    alert(e.response?.data?.msg || '删除失败')
+  }
+}
+</script>
+
+<style scoped>
+.page {
+  padding: 20px;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -10,6 +10,7 @@ import GameOver from '../pages/GameOver.vue'
 import Ranking from '../pages/Ranking.vue'
 import Help from '../pages/Help.vue'
 import Admin from '../pages/Admin.vue'
+import ItemAdmin from '../pages/ItemAdmin.vue'
 
 const routes = [
   { path: '/', name: 'Home', component: Home },
@@ -23,6 +24,7 @@ const routes = [
   { path: '/ranking', name: 'Ranking', component: Ranking },
   { path: '/help', name: 'Help', component: Help },
   { path: '/admin', name: 'Admin', component: Admin },
+  { path: '/admin/items', name: 'ItemAdmin', component: ItemAdmin },
 ]
 
 const router = createRouter({

--- a/mogoDB.md/items.md
+++ b/mogoDB.md/items.md
@@ -1,0 +1,23 @@
+# items 集合示例
+
+`items` 用于存放角色生成时可能出现的全部基础物品，包括初始武器。
+
+```javascript
+use dts;
+db.items.insertMany([
+  { name: '面包', kind: 'HH', effect: 100, dur: '30', skill: '' },
+  { name: '菜刀', kind: 'WK', effect: 15, dur: '10', skill: '' }
+]);
+```
+
+创建集合后建议为 `name` 字段建立索引：
+
+```javascript
+db.items.createIndex({ name: 1 });
+```
+
+项目 `data/items.json` 已汇总了全部物品，可使用如下命令批量导入：
+
+```bash
+mongoimport --db dts --collection items --file ../data/items.json --jsonArray
+```


### PR DESCRIPTION
## Summary
- introduce Item model to store base item stats
- load starter items from database when entering a game
- support `/admin/items` API filtering by kind
- document items collection and dataset import
- update frontend router and add ItemAdmin page using Segmented control
- include items.json dataset and import in init script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882de205aa88322b1131e1ebc3df9dd