### PR TITLE
Implement automatic token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ npm run lint     # 代码规范检查
 - **POST `/api/auth/refresh`**：使用 `refreshToken` 获取新的 `token`
 - **POST `/api/auth/logout`**：注销并清除服务器端的 `refreshToken`
 
+客户端在收到 `令牌过期` 响应时会自动调用 `/api/auth/refresh`，
+刷新成功后重试原请求，无需手动重新登录。
+
 ## 管理 API
 
 管理员登录后可通过以下接口管理数据：

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { ElMessageBox } from 'element-plus'
 import router from '../router'
 import { user, token, refreshToken, playerId } from '../store/user'
+import { refresh as refreshApi } from './auth'
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api'
@@ -15,28 +16,58 @@ api.interceptors.request.use(config => {
 })
 
 let showingExpired = false
+let refreshing = null
+
+async function handleRefresh() {
+  if (!refreshToken.value) return false
+  if (!refreshing) {
+    refreshing = refreshApi(refreshToken.value)
+      .then(({ data }) => {
+        token.value = data.token
+        localStorage.setItem('token', token.value)
+        refreshing = null
+        return true
+      })
+      .catch(() => {
+        refreshing = null
+        return false
+      })
+  }
+  try {
+    return await refreshing
+  } catch {
+    return false
+  }
+}
 
 api.interceptors.response.use(
   response => response,
   async error => {
     const msg = error.response?.data?.msg
-    if (error.response?.status === 401 && msg === '令牌过期' && !showingExpired) {
-      showingExpired = true
-      await ElMessageBox.alert('登录已过期，请重新登录', '提示', {
-        confirmButtonText: '返回主页',
-        callback: () => {
-          user.value = ''
-          token.value = ''
-          refreshToken.value = ''
-          playerId.value = ''
-          localStorage.removeItem('user')
-          localStorage.removeItem('token')
-          localStorage.removeItem('refreshToken')
-          localStorage.removeItem('playerId')
-          router.push('/')
-          showingExpired = false
-        }
-      })
+    if (error.response?.status === 401 && msg === '令牌过期') {
+      const refreshed = await handleRefresh()
+      if (refreshed) {
+        error.config.headers.Authorization = `Bearer ${token.value}`
+        return api(error.config)
+      }
+      if (!showingExpired) {
+        showingExpired = true
+        await ElMessageBox.alert('登录已过期，请重新登录', '提示', {
+          confirmButtonText: '返回主页',
+          callback: () => {
+            user.value = ''
+            token.value = ''
+            refreshToken.value = ''
+            playerId.value = ''
+            localStorage.removeItem('user')
+            localStorage.removeItem('token')
+            localStorage.removeItem('refreshToken')
+            localStorage.removeItem('playerId')
+            router.push('/')
+            showingExpired = false
+          }
+        })
+      }
     }
     return Promise.reject(error)
   }


### PR DESCRIPTION
## Summary
- auto-refresh expired tokens in `client.js`
- document refresh mechanism in README

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` in frontend *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e005f64c832282528603d7d170a5