### PR TITLE
Fix item category in admin

### DIFF
--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -68,6 +68,7 @@ const collections = [
   { label: '玩家', value: 'players' },
   { label: 'NPC', value: 'npcs' },
   { label: '商店物品', value: 'shopitems' },
+  { label: '物品表', value: 'items' },
   { label: '日志', value: 'logs' },
   { label: '聊天', value: 'chats' },
   { label: '地图物品', value: 'mapitems' },


### PR DESCRIPTION
## Summary
- add missing `items` category to the game admin collections list

## Testing
- `npm test` in `backend` (fails: no test specified)
- `npm run build` in `frontend` (fails: vite not found)

------
https://chatgpt.com/codex/tasks/task_e_6882e2a3ac2c83229c231944757d81e2