### PR TITLE
fix: remove redundant ElementPlus plugin registration

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,13 +2,10 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import ElementPlus from 'element-plus'
-import { ElInfiniteScroll, ElLoading } from 'element-plus'
 import 'element-plus/dist/index.css'
 import './style.css'
 
 const app = createApp(App)
 app.use(router)
 app.use(ElementPlus)
-app.use(ElInfiniteScroll)
-app.use(ElLoading)
 app.mount('#app')


### PR DESCRIPTION
## Summary
- avoid duplicate plugin registration in ElementPlus

## Testing
- `npm test` in frontend (fails: Missing script)
- `npm test` in backend (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6882eda172608322980790fe87a581bb