### PR TITLE
Separate log from chat

### DIFF
--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -7,8 +7,8 @@
         <PlayerStats v-if="info" :info="info" :injuries="injuries" />
         <BattlePanel v-if="enemy" :player="info" :enemy="enemy" :loot="lootItems" @attack="doAttack" @loot="doLoot" />
         <EquipmentList v-if="info" :rows="equipRows" @unequip="unequip" @drop="dropEquipItem" />
+        <LogPanel :logs="recentLogs" />
         <ChatPanel :messages="chatList" @send="sendChatMsg" />
-        <LogPanel :logs="logs" />
       </div>
 
       <!-- 右侧区域 -->
@@ -163,10 +163,11 @@ const bagItems = computed(() => {
   return res
 })
 
+const recentLogs = computed(() => logs.value.slice(0, 2))
+
 function addLog(message) {
   if (message) {
     logs.value.unshift(message)
-    addChat({ type: 2, msg: message, time: Date.now() })
   }
 }
 


### PR DESCRIPTION
## Summary
- place log panel above chat panel and show only last two log entries
- remove routing of logs to chat messages

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882ef81570483228a22c32005a0d30f