### PR TITLE
Enhance home page with statistics

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -3,15 +3,43 @@
     <h2>欢迎来到 DTS</h2>
     <div class="home-container">
       <div class="game-info">
-        <p>游戏版本：{{ gameInfo.version ?? '未知' }}</p>
-        <p>当前时刻：{{ formatTime(currentTime) }}</p>
-        <p>状态：{{ gameStatus }}</p>
-        <p>已运行：{{ runtime }}</p>
-        <p>禁区数：{{ gameInfo.areanum ?? '无法获取' }}</p>
-        <p>存活玩家：{{ gameInfo.alivenum ?? '无法获取' }}</p>
-        <p>死亡总数：{{ gameInfo.deathnum ?? '无法获取' }}</p>
-        <el-button size="small" type="primary" @click="manualStart">手动开始游戏</el-button>
-        <el-button size="small" type="danger" @click="manualStop" style="margin-left: 8px">手动关闭游戏</el-button>
+        <el-row :gutter="20" class="stats">
+          <el-col :span="8">
+            <el-statistic title="游戏版本">
+              <template #default>{{ gameInfo.version ?? '未知' }}</template>
+            </el-statistic>
+          </el-col>
+          <el-col :span="8">
+            <el-statistic :value="currentTime" title="当前时刻">
+              <template #formatter="{ value }">{{ formatTime(value) }}</template>
+            </el-statistic>
+          </el-col>
+          <el-col :span="8">
+            <el-statistic title="状态">
+              <template #default>{{ gameStatus }}</template>
+            </el-statistic>
+          </el-col>
+        </el-row>
+        <el-row :gutter="20" class="stats">
+          <el-col :span="6">
+            <el-statistic title="已运行">
+              <template #default>{{ runtime }}</template>
+            </el-statistic>
+          </el-col>
+          <el-col :span="6">
+            <el-statistic :value="gameInfo.areanum ?? 0" title="禁区数" />
+          </el-col>
+          <el-col :span="6">
+            <el-statistic :value="gameInfo.alivenum ?? 0" title="存活玩家" />
+          </el-col>
+          <el-col :span="6">
+            <el-statistic :value="gameInfo.deathnum ?? 0" title="死亡总数" />
+          </el-col>
+        </el-row>
+        <div class="btn-group">
+          <el-button size="small" type="primary" @click="manualStart">手动开始游戏</el-button>
+          <el-button size="small" type="danger" @click="manualStop" style="margin-left: 8px">手动关闭游戏</el-button>
+        </div>
       </div>
       <div v-if="!loggedIn" class="auth-box">
         <el-tabs v-model="activeTab" stretch>
@@ -215,6 +243,12 @@ async function logout() {
 }
 .game-info {
   margin-bottom: 20px;
+}
+.stats {
+  margin-bottom: 12px;
+}
+.btn-group {
+  margin-top: 10px;
 }
 @media (max-width: 600px) {
   .home-container {


### PR DESCRIPTION
## Summary
- improve Home page layout with Element Plus `<el-statistic>` components
- add styles for stats section and button group

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688308a5d180832294c4085bdf5dc0e3