### PR TITLE
Fix statistic display on home page

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -10,9 +10,11 @@
             </el-statistic>
           </el-col>
           <el-col :span="8">
-            <el-statistic :value="currentTime" title="当前时刻">
-              <template #formatter="{ value }">{{ formatTime(value) }}</template>
-            </el-statistic>
+            <el-statistic
+              :value="currentTime"
+              title="当前时刻"
+              :formatter="formatTime"
+            />
           </el-col>
           <el-col :span="8">
             <el-statistic title="状态">
@@ -108,7 +110,7 @@ function formatTime(t) {
 
 const gameStatus = computed(() => {
   if (!Object.keys(gameInfo.value).length) return '无法获取'
-  return gameInfo.value.gamestate > 10 ? '进行中' : '未开始'
+  return gameInfo.value.gamestate >= 20 ? '进行中' : '未开始'
 })
 
 const runtime = computed(() => {


### PR DESCRIPTION
## Summary
- fix Element Plus statistic usage
- update game status check in home page

## Testing
- `npm test --prefix backend` *(fails: no test specified)*
- `npm test --prefix frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688309f11fd48322a05f34437e28e9bc