### PR TITLE
Fix home page game status and runtime display

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -110,12 +110,16 @@ function formatTime(t) {
 
 const gameStatus = computed(() => {
   if (!Object.keys(gameInfo.value).length) return '无法获取'
-  return gameInfo.value.gamestate >= 20 ? '进行中' : '未开始'
+  const state = gameInfo.value.gamestate
+  if (state >= 30) return '锁定'
+  if (state >= 20) return '进行中'
+  if (state > 0) return '未开始'
+  return '已结束'
 })
 
 const runtime = computed(() => {
   if (!gameInfo.value?.starttime) return 'N/A'
-  const diff = Date.now() - gameInfo.value.starttime * 1000
+  const diff = currentTime.value - gameInfo.value.starttime * 1000
   const h = Math.floor(diff / 3600000)
   const m = Math.floor((diff % 3600000) / 60000)
   const s = Math.floor((diff % 60000) / 1000)


### PR DESCRIPTION
## Summary
- translate numeric gamestate to human readable status
- update runtime calculation to use reactive current time

## Testing
- `npm run lint` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68830cb0d8b88322b5ba6a9524d967c1