### PR TITLE
Update version and admin menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ npm run lint     # 代码规范检查
 
   ```json
   {
-    "version": "1.0",
+    "version": "1.0.1",
     "gamestate": "active",
     "starttime": 0,
     "areaInterval": 0,

--- a/backend/src/models/GameInfo.js
+++ b/backend/src/models/GameInfo.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 
 const gameInfoSchema = new mongoose.Schema({
-  version: { type: String, default: '1.0' },
+  version: { type: String, default: '1.0.1' },
   gamenum: { type: Number, default: 0 },
   gametype: { type: Number, default: 0 },
   gamestate: { type: Number, default: 0 },

--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -71,7 +71,7 @@ async function startGame() {
   const now = Math.floor(Date.now() / 1000);
   if (!info) {
     info = await GameInfo.create({
-      version: '1.0',
+      version: '1.0.1',
       gamenum: 1,
       gamestate: 20,
       starttime: now,
@@ -200,7 +200,7 @@ async function spawnNpcs(stage) {
 async function stopGame() {
   let info = await GameInfo.findOne();
   if (!info) {
-    info = await GameInfo.create({ version: '1.0', gamestate: 0 });
+    info = await GameInfo.create({ version: '1.0.1', gamestate: 0 });
   } else {
     const now = Math.floor(Date.now() / 1000);
     if (info.gamestate > 10 && info.starttime) {

--- a/data/gameinfo.json
+++ b/data/gameinfo.json
@@ -1,6 +1,6 @@
 [
   {
-    "version": "1.0",
+    "version": "1.0.1",
     "gamenum": 0,
     "gametype": 0,
     "gamestate": 0,

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -73,6 +73,7 @@ const collections = [
   { label: '聊天', value: 'chats' },
   { label: '地图物品', value: 'mapitems' },
   { label: '陷阱', value: 'maptraps' },
+  { label: '物品类别', value: 'itemcategories' },
   { label: '新闻', value: 'newsinfos' },
   { label: '房间监听', value: 'roomlisteners' },
   { label: '历史记录', value: 'histories' },

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -5,7 +5,7 @@
       <div class="game-info">
         <el-row :gutter="20" class="stats">
           <el-col :span="8">
-            <el-statistic title="游戏版本">
+            <el-statistic :value="null" title="游戏版本">
               <template #default>{{ gameInfo.version ?? '未知' }}</template>
             </el-statistic>
           </el-col>
@@ -17,14 +17,14 @@
             />
           </el-col>
           <el-col :span="8">
-            <el-statistic title="状态">
+            <el-statistic :value="null" title="状态">
               <template #default>{{ gameStatus }}</template>
             </el-statistic>
           </el-col>
         </el-row>
         <el-row :gutter="20" class="stats">
           <el-col :span="6">
-            <el-statistic title="已运行">
+            <el-statistic :value="null" title="已运行">
               <template #default>{{ runtime }}</template>
             </el-statistic>
           </el-col>


### PR DESCRIPTION
## Summary
- show string-based stats without default `0` on Home
- support editing item categories in admin menu
- bump game version to **1.0.1**

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test"*)


------
https://chatgpt.com/codex/tasks/task_e_68830fac28fc832284649e9d5ff071c9