### PR TITLE
Fix mapitem spawn stages

### DIFF
--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -57,7 +57,20 @@ async function generateItemsFromCategories(type, stage = 'start') {
 }
 
 async function spawnMapItems(stage) {
-  const items = await generateItemsFromCategories('mapitem', stage);
+  let items = await generateItemsFromCategories('mapitem', stage);
+  if (!items.length) {
+    let file = '../data/mapitems.json';
+    if (stage === 'ban2') file = '../data/mapitems_ban2.json';
+    else if (stage === 'ban4') file = '../data/mapitems_ban4.json';
+    try {
+      const fp = path.join(__dirname, file);
+      if (fs.existsSync(fp)) {
+        items = JSON.parse(fs.readFileSync(fp));
+      }
+    } catch (e) {
+      console.error('读取默认地图物品失败', e);
+    }
+  }
   if (items.length) await MapItem.insertMany(items);
 }
 

--- a/data/mapitems_ban2.json
+++ b/data/mapitems_ban2.json
@@ -1,0 +1,1928 @@
+[
+  {
+    "iid": 1,
+    "itm": "★多鲁基★",
+    "itmk": "WC",
+    "itme": 2000,
+    "itms": "1",
+    "itmsk": "c",
+    "pls": 2
+  },
+  {
+    "iid": 2,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 3,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 4,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 5,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 6,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 7,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 8,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 9,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 10,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 11,
+    "itm": "手机",
+    "itmk": "X",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 2
+  },
+  {
+    "iid": 12,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 13,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 14,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 15,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 16,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 17,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 18,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 19,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 20,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 21,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 22,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 23,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 24,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 25,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 26,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 27,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 3
+  },
+  {
+    "iid": 28,
+    "itm": "【宇航服】",
+    "itmk": "DB",
+    "itme": 160,
+    "itms": "30",
+    "itmsk": "a",
+    "pls": 4
+  },
+  {
+    "iid": 29,
+    "itm": "【宇航服】",
+    "itmk": "DB",
+    "itme": 160,
+    "itms": "30",
+    "itmsk": "a",
+    "pls": 4
+  },
+  {
+    "iid": 30,
+    "itm": "生命探测器",
+    "itmk": "ER",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 4
+  },
+  {
+    "iid": 31,
+    "itm": "生命探测器",
+    "itmk": "ER",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 4
+  },
+  {
+    "iid": 32,
+    "itm": "生命探测器",
+    "itmk": "ER",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 4
+  },
+  {
+    "iid": 33,
+    "itm": "生命探测器",
+    "itmk": "ER",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 4
+  },
+  {
+    "iid": 34,
+    "itm": "生命探测器",
+    "itmk": "ER",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 4
+  },
+  {
+    "iid": 35,
+    "itm": "向日葵",
+    "itmk": "HS",
+    "itme": 50,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "iid": 36,
+    "itm": "向日葵",
+    "itmk": "HS",
+    "itme": 50,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "iid": 37,
+    "itm": "向日葵",
+    "itmk": "HS",
+    "itme": 50,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 6
+  },
+  {
+    "iid": 38,
+    "itm": "落魂符",
+    "itmk": "WF",
+    "itme": 20,
+    "itms": "30",
+    "itmsk": "d",
+    "pls": 8
+  },
+  {
+    "iid": 39,
+    "itm": "落魂符",
+    "itmk": "WF",
+    "itme": 20,
+    "itms": "30",
+    "itmsk": "d",
+    "pls": 8
+  },
+  {
+    "iid": 40,
+    "itm": "落魂符",
+    "itmk": "WF",
+    "itme": 20,
+    "itms": "30",
+    "itmsk": "d",
+    "pls": 8
+  },
+  {
+    "iid": 41,
+    "itm": "落魂符",
+    "itmk": "WF",
+    "itme": 20,
+    "itms": "30",
+    "itmsk": "d",
+    "pls": 8
+  },
+  {
+    "iid": 42,
+    "itm": "落魂符",
+    "itmk": "WF",
+    "itme": 20,
+    "itms": "30",
+    "itmsk": "d",
+    "pls": 8
+  },
+  {
+    "iid": 43,
+    "itm": "彩虹光芒的羽毛",
+    "itmk": "WK",
+    "itme": 75,
+    "itms": "750",
+    "itmsk": "i",
+    "pls": 8
+  },
+  {
+    "iid": 44,
+    "itm": "彩虹光芒的羽毛",
+    "itmk": "WK",
+    "itme": 75,
+    "itms": "750",
+    "itmsk": "i",
+    "pls": 8
+  },
+  {
+    "iid": 45,
+    "itm": "彩虹光芒的羽毛",
+    "itmk": "WK",
+    "itme": 75,
+    "itms": "750",
+    "itmsk": "i",
+    "pls": 8
+  },
+  {
+    "iid": 46,
+    "itm": "彩虹光芒的羽毛",
+    "itmk": "WK",
+    "itme": 75,
+    "itms": "750",
+    "itmsk": "i",
+    "pls": 8
+  },
+  {
+    "iid": 47,
+    "itm": "彩虹光芒的羽毛",
+    "itmk": "WK",
+    "itme": 75,
+    "itms": "750",
+    "itmsk": "i",
+    "pls": 8
+  },
+  {
+    "iid": 48,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 49,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 50,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 51,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 52,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 53,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 54,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 55,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 56,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 57,
+    "itm": "【奈落的落穴】",
+    "itmk": "TN",
+    "itme": 700,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 9
+  },
+  {
+    "iid": 58,
+    "itm": "岩石",
+    "itmk": "WC",
+    "itme": 10,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 10
+  },
+  {
+    "iid": 59,
+    "itm": "岩石",
+    "itmk": "WC",
+    "itme": 10,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 10
+  },
+  {
+    "iid": 60,
+    "itm": "岩石",
+    "itmk": "WC",
+    "itme": 10,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 10
+  },
+  {
+    "iid": 61,
+    "itm": "岩石",
+    "itmk": "WC",
+    "itme": 10,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 10
+  },
+  {
+    "iid": 62,
+    "itm": "岩石",
+    "itmk": "WC",
+    "itme": 10,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 10
+  },
+  {
+    "iid": 63,
+    "itm": "岩石",
+    "itmk": "WC",
+    "itme": 10,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 10
+  },
+  {
+    "iid": 64,
+    "itm": "岩石",
+    "itmk": "WC",
+    "itme": 10,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 10
+  },
+  {
+    "iid": 65,
+    "itm": "岩石",
+    "itmk": "WC",
+    "itme": 10,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 10
+  },
+  {
+    "iid": 66,
+    "itm": "★好折凳★",
+    "itmk": "WP",
+    "itme": 200,
+    "itms": "15",
+    "itmsk": "N",
+    "pls": 11
+  },
+  {
+    "iid": 67,
+    "itm": "★好折凳★",
+    "itmk": "WP",
+    "itme": 200,
+    "itms": "15",
+    "itmsk": "N",
+    "pls": 11
+  },
+  {
+    "iid": 68,
+    "itm": "★好折凳★",
+    "itmk": "WP",
+    "itme": 200,
+    "itms": "15",
+    "itmsk": "N",
+    "pls": 11
+  },
+  {
+    "iid": 69,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 70,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 71,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 72,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 73,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 74,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 75,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 76,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 77,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 78,
+    "itm": "钉",
+    "itmk": "Y",
+    "itme": 10,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 11
+  },
+  {
+    "iid": 79,
+    "itm": "碗",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "24",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 80,
+    "itm": "碗",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "24",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 81,
+    "itm": "碗",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "24",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 82,
+    "itm": "碗",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "24",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 83,
+    "itm": "碗",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "24",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 84,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 85,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 86,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 87,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 88,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 89,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 90,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 91,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 92,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 93,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 94,
+    "itm": "杯子",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 95,
+    "itm": "杯子",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 96,
+    "itm": "杯子",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 97,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 98,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 99,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 100,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 101,
+    "itm": "针线包",
+    "itmk": "Y",
+    "itme": 60,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 102,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 8,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 103,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 8,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 104,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 8,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 105,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 8,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 12
+  },
+  {
+    "iid": 106,
+    "itm": "强相互作用【水滴】",
+    "itmk": "WC",
+    "itme": 650,
+    "itms": "3",
+    "itmsk": "",
+    "pls": 13
+  },
+  {
+    "iid": 107,
+    "itm": "强相互作用【水滴】",
+    "itmk": "WC",
+    "itme": 650,
+    "itms": "3",
+    "itmsk": "",
+    "pls": 13
+  },
+  {
+    "iid": 108,
+    "itm": "强相互作用【水滴】",
+    "itmk": "WC",
+    "itme": 650,
+    "itms": "3",
+    "itmsk": "",
+    "pls": 13
+  },
+  {
+    "iid": 109,
+    "itm": "强相互作用【水滴】",
+    "itmk": "WC",
+    "itme": 650,
+    "itms": "3",
+    "itmsk": "",
+    "pls": 13
+  },
+  {
+    "iid": 110,
+    "itm": "驱云弹",
+    "itmk": "EW",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "1",
+    "pls": 13
+  },
+  {
+    "iid": 111,
+    "itm": "奇迹【神之风】",
+    "itmk": "WF",
+    "itme": 200,
+    "itms": "10",
+    "itmsk": "",
+    "pls": 15
+  },
+  {
+    "iid": 112,
+    "itm": "奇迹【神之风】",
+    "itmk": "WF",
+    "itme": 200,
+    "itms": "10",
+    "itmsk": "",
+    "pls": 15
+  },
+  {
+    "iid": 113,
+    "itm": "祟符【诹访明神】",
+    "itmk": "WF",
+    "itme": 200,
+    "itms": "5",
+    "itmsk": "d",
+    "pls": 15
+  },
+  {
+    "iid": 114,
+    "itm": "祟符【诹访明神】",
+    "itmk": "WF",
+    "itme": 200,
+    "itms": "5",
+    "itmsk": "d",
+    "pls": 15
+  },
+  {
+    "iid": 115,
+    "itm": "乱入【御社神的作祟】",
+    "itmk": "WF",
+    "itme": 500,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 15
+  },
+  {
+    "iid": 116,
+    "itm": "【幻想御手】",
+    "itmk": "MV",
+    "itme": 25,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "iid": 117,
+    "itm": "【幻想御手】",
+    "itmk": "MV",
+    "itme": 25,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "iid": 118,
+    "itm": "红石榴汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "iid": 119,
+    "itm": "红石榴汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "iid": 120,
+    "itm": "红石榴汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "iid": 121,
+    "itm": "红石榴汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "iid": 122,
+    "itm": "红石榴汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 17
+  },
+  {
+    "iid": 123,
+    "itm": "立顿茶包",
+    "itmk": "HB",
+    "itme": 15,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 124,
+    "itm": "立顿茶包",
+    "itmk": "HB",
+    "itme": 15,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 125,
+    "itm": "立顿茶包",
+    "itmk": "HB",
+    "itme": 15,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 126,
+    "itm": "立顿茶包",
+    "itmk": "HB",
+    "itme": 15,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 127,
+    "itm": "立顿茶包",
+    "itmk": "HB",
+    "itme": 15,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 128,
+    "itm": "立顿茶包",
+    "itmk": "HB",
+    "itme": 15,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 129,
+    "itm": "立顿茶包",
+    "itmk": "HB",
+    "itme": 15,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 130,
+    "itm": "立顿茶包",
+    "itmk": "HB",
+    "itme": 15,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 131,
+    "itm": "碗",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "24",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 132,
+    "itm": "碗",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "24",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 133,
+    "itm": "碗",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "24",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 134,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 135,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 136,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 137,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 138,
+    "itm": "锅",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "12",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 139,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 140,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 141,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 142,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 143,
+    "itm": "玻璃杯",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "30",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 144,
+    "itm": "杯子",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "20",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 145,
+    "itm": "杯子",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "20",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 146,
+    "itm": "杯子",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "20",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 147,
+    "itm": "杯子",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "20",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 148,
+    "itm": "杯子",
+    "itmk": "WC",
+    "itme": 5,
+    "itms": "20",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 149,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 6,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 150,
+    "itm": "磨刀石",
+    "itmk": "Y",
+    "itme": 6,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 18
+  },
+  {
+    "iid": 151,
+    "itm": "『奥丁巨核装备』",
+    "itmk": "WG",
+    "itme": 600,
+    "itms": "48",
+    "itmsk": "uewo",
+    "pls": 21
+  },
+  {
+    "iid": 152,
+    "itm": "『奥丁巨核装备』",
+    "itmk": "WG",
+    "itme": 600,
+    "itms": "48",
+    "itmsk": "uewo",
+    "pls": 21
+  },
+  {
+    "iid": 153,
+    "itm": "『干扰用强袭装备』",
+    "itmk": "WG",
+    "itme": 540,
+    "itms": "48",
+    "itmsk": "epo",
+    "pls": 21
+  },
+  {
+    "iid": 154,
+    "itm": "『干扰用强袭装备』",
+    "itmk": "WG",
+    "itme": 540,
+    "itms": "48",
+    "itmsk": "epo",
+    "pls": 21
+  },
+  {
+    "iid": 155,
+    "itm": "『干扰用强袭装备』",
+    "itmk": "WG",
+    "itme": 540,
+    "itms": "48",
+    "itmsk": "epo",
+    "pls": 21
+  },
+  {
+    "iid": 156,
+    "itm": "『对舰用闪击装备』",
+    "itmk": "WG",
+    "itme": 540,
+    "itms": "48",
+    "itmsk": "uio",
+    "pls": 21
+  },
+  {
+    "iid": 157,
+    "itm": "『对舰用闪击装备』",
+    "itmk": "WG",
+    "itme": 540,
+    "itms": "48",
+    "itmsk": "uio",
+    "pls": 21
+  },
+  {
+    "iid": 158,
+    "itm": "『对舰用闪击装备』",
+    "itmk": "WG",
+    "itme": 540,
+    "itms": "48",
+    "itmsk": "uio",
+    "pls": 21
+  },
+  {
+    "iid": 159,
+    "itm": "『传说中的旋风激光』",
+    "itmk": "WG",
+    "itme": 1146,
+    "itms": "64",
+    "itmsk": "NZ",
+    "pls": 21
+  },
+  {
+    "iid": 160,
+    "itm": "『传说中的穿刺激光』",
+    "itmk": "WG",
+    "itme": 1146,
+    "itms": "64",
+    "itmsk": "nZ",
+    "pls": 21
+  },
+  {
+    "iid": 161,
+    "itm": "高性能『天使队』制服",
+    "itmk": "DB",
+    "itme": 221,
+    "itms": "221",
+    "itmsk": "A",
+    "pls": 21
+  },
+  {
+    "iid": 162,
+    "itm": "高性能『天使队』制服",
+    "itmk": "DB",
+    "itme": 221,
+    "itms": "221",
+    "itmsk": "A",
+    "pls": 21
+  },
+  {
+    "iid": 163,
+    "itm": "高性能『天使队』制服",
+    "itmk": "DB",
+    "itme": 221,
+    "itms": "221",
+    "itmsk": "A",
+    "pls": 21
+  },
+  {
+    "iid": 164,
+    "itm": "柠檬汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 165,
+    "itm": "柠檬汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 166,
+    "itm": "柠檬汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 167,
+    "itm": "柠檬汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 168,
+    "itm": "柠檬汁",
+    "itmk": "HS",
+    "itme": 75,
+    "itms": "2",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 169,
+    "itm": "奇迹-永恒",
+    "itmk": "HB",
+    "itme": 3454,
+    "itms": "3",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 170,
+    "itm": "奇迹-永恒",
+    "itmk": "HB",
+    "itme": 3454,
+    "itms": "3",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 171,
+    "itm": "奇迹-永恒",
+    "itmk": "HB",
+    "itme": 3454,
+    "itms": "3",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 172,
+    "itm": "冰封的『χ-blade』",
+    "itmk": "WK",
+    "itme": 60,
+    "itms": "3",
+    "itmsk": "pui",
+    "pls": 26
+  },
+  {
+    "iid": 173,
+    "itm": "冰封的『χ-blade』",
+    "itmk": "WK",
+    "itme": 60,
+    "itms": "3",
+    "itmsk": "pui",
+    "pls": 26
+  },
+  {
+    "iid": 174,
+    "itm": "冰封的『虚空装备』",
+    "itmk": "WK",
+    "itme": 40,
+    "itms": "4",
+    "itmsk": "pw",
+    "pls": 26
+  },
+  {
+    "iid": 175,
+    "itm": "冰封的『虚空装备』",
+    "itmk": "WK",
+    "itme": 40,
+    "itms": "4",
+    "itmsk": "pw",
+    "pls": 26
+  },
+  {
+    "iid": 176,
+    "itm": "冰封的『无名』",
+    "itmk": "WK",
+    "itme": 40,
+    "itms": "4",
+    "itmsk": "u",
+    "pls": 26
+  },
+  {
+    "iid": 177,
+    "itm": "冰封的『无名』",
+    "itmk": "WK",
+    "itme": 40,
+    "itms": "4",
+    "itmsk": "u",
+    "pls": 26
+  },
+  {
+    "iid": 178,
+    "itm": "【心灵风暴】",
+    "itmk": "WD",
+    "itme": 256,
+    "itms": "6",
+    "itmsk": "wdy",
+    "pls": 28
+  },
+  {
+    "iid": 179,
+    "itm": "【心灵风暴】",
+    "itmk": "WD",
+    "itme": 256,
+    "itms": "6",
+    "itmsk": "wdy",
+    "pls": 28
+  },
+  {
+    "iid": 180,
+    "itm": "【心灵风暴】",
+    "itmk": "WD",
+    "itme": 256,
+    "itms": "6",
+    "itmsk": "wdy",
+    "pls": 28
+  },
+  {
+    "iid": 181,
+    "itm": "★中子地雷★",
+    "itmk": "TN",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "iid": 182,
+    "itm": "★中子地雷★",
+    "itmk": "TN",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "iid": 183,
+    "itm": "★中子地雷★",
+    "itmk": "TN",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "iid": 184,
+    "itm": "★中子地雷★",
+    "itmk": "TN",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "iid": 185,
+    "itm": "★中子地雷★",
+    "itmk": "TN",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "iid": 186,
+    "itm": "★中子地雷★",
+    "itmk": "TN",
+    "itme": 800,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 28
+  },
+  {
+    "iid": 187,
+    "itm": "达人的太鼓棍棒",
+    "itmk": "WP",
+    "itme": 765,
+    "itms": "765",
+    "itmsk": "N",
+    "pls": 31
+  },
+  {
+    "iid": 188,
+    "itm": "达人的太鼓棍棒",
+    "itmk": "WP",
+    "itme": 765,
+    "itms": "765",
+    "itmsk": "N",
+    "pls": 31
+  },
+  {
+    "iid": 189,
+    "itm": "究级篝酱加农炮",
+    "itmk": "WG",
+    "itme": 4800,
+    "itms": "200",
+    "itmsk": "ir",
+    "pls": 33
+  },
+  {
+    "iid": 190,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 191,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 192,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 193,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 194,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 195,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 196,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 197,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 198,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 199,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 200,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 201,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 202,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 203,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 204,
+    "itm": "杂炊",
+    "itmk": "HS",
+    "itme": 120,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 205,
+    "itm": "★超能力爆发★",
+    "itmk": "WF",
+    "itme": 144,
+    "itms": "∞",
+    "itmsk": "dn",
+    "pls": 99
+  },
+  {
+    "iid": 206,
+    "itm": "■DeathNote■",
+    "itmk": "Y",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "z",
+    "pls": 99
+  },
+  {
+    "iid": 207,
+    "itm": "奇怪的按钮",
+    "itmk": "Z",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  },
+  {
+    "iid": 208,
+    "itm": "★AT力场★",
+    "itmk": "DB",
+    "itme": 200,
+    "itms": "20",
+    "itmsk": "A",
+    "pls": 99
+  },
+  {
+    "iid": 209,
+    "itm": "【主角光环】",
+    "itmk": "DH",
+    "itme": 250,
+    "itms": "250",
+    "itmsk": "AM",
+    "pls": 99
+  },
+  {
+    "iid": 210,
+    "itm": "瘴气发生器",
+    "itmk": "EW",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "10",
+    "pls": 99
+  },
+  {
+    "iid": 211,
+    "itm": "龙卷风发生器",
+    "itmk": "EW",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "11",
+    "pls": 99
+  },
+  {
+    "iid": 212,
+    "itm": "暴风雪发生器",
+    "itmk": "EW",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "12",
+    "pls": 99
+  },
+  {
+    "iid": 213,
+    "itm": "冰雹发生器",
+    "itmk": "EW",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "13",
+    "pls": 99
+  },
+  {
+    "iid": 214,
+    "itm": "鲜红的生血",
+    "itmk": "PB",
+    "itme": 580,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 99
+  }
+]

--- a/data/mapitems_ban4.json
+++ b/data/mapitems_ban4.json
@@ -1,0 +1,38 @@
+[
+  {
+    "iid": 1,
+    "itm": "奇怪的按钮",
+    "itmk": "Z",
+    "itme": 1,
+    "itms": "1",
+    "itmsk": "",
+    "pls": 13
+  },
+  {
+    "iid": 2,
+    "itm": "奇迹-友情",
+    "itmk": "HB",
+    "itme": 5676,
+    "itms": "5",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 3,
+    "itm": "奇迹-友情",
+    "itmk": "HB",
+    "itme": 5676,
+    "itms": "5",
+    "itmsk": "",
+    "pls": 22
+  },
+  {
+    "iid": 4,
+    "itm": "奇迹-友情",
+    "itmk": "HB",
+    "itme": 5676,
+    "itms": "5",
+    "itmsk": "",
+    "pls": 22
+  }
+]

--- a/scripts/generateMapData.js
+++ b/scripts/generateMapData.js
@@ -17,22 +17,50 @@ function parseMapAreas() {
 }
 
 function parseMapItems() {
-  const file = path.join(__dirname, '../DTS-SAMPLE/include/modules/base/itemmain/config/mapitem.config.php');
+  const file = path.join(
+    __dirname,
+    '../DTS-SAMPLE/include/modules/base/itemmain/config/mapitem.config.php',
+  );
   const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
-  const result = [];
-  let iid = 1;
+  const stages = { start: [], ban2: [], ban4: [] };
+  const ids = { start: 1, ban2: 1, ban4: 1 };
+
   for (const line of lines) {
     const t = line.trim();
     if (!t || t.startsWith('//') || t.startsWith('<?')) continue;
     const parts = t.split(',');
     if (parts.length < 8) continue;
     const [time, area, num, itm, itmk, itme, itms, itmsk] = parts;
-    if (parseInt(time) !== 0) continue; // only start items
+    let stage = null;
+    if (parseInt(time) === 0) stage = 'start';
+    else if (parseInt(time) === 2) stage = 'ban2';
+    else if (parseInt(time) === 4) stage = 'ban4';
+    if (!stage) continue;
     for (let i = 0; i < parseInt(num); i++) {
-      result.push({ iid: iid++, itm, itmk, itme: Number(itme), itms: itms, itmsk, pls: Number(area) });
+      stages[stage].push({
+        iid: ids[stage]++,
+        itm,
+        itmk,
+        itme: Number(itme),
+        itms,
+        itmsk,
+        pls: Number(area),
+      });
     }
   }
-  fs.writeFileSync(path.join(__dirname, '../data/mapitems.json'), JSON.stringify(result, null, 2));
+
+  fs.writeFileSync(
+    path.join(__dirname, '../data/mapitems.json'),
+    JSON.stringify(stages.start, null, 2),
+  );
+  fs.writeFileSync(
+    path.join(__dirname, '../data/mapitems_ban2.json'),
+    JSON.stringify(stages.ban2, null, 2),
+  );
+  fs.writeFileSync(
+    path.join(__dirname, '../data/mapitems_ban4.json'),
+    JSON.stringify(stages.ban4, null, 2),
+  );
 }
 
 parseMapAreas();


### PR DESCRIPTION
## Summary
- parse additional mapitem stages from DTS-SAMPLE mapitem config
- provide default ban2 and ban4 mapitem lists
- load mapitems for ban2 and ban4 when ItemCategory data is missing

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688311fc685c8322af70c828359a4b28