### PR TITLE
Fix home page info display

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -22,6 +22,7 @@ mongoose
     console.log('MongoDB 已连接');
     await constantsService.loadConstants();
     await gameService.ensureDefaultClubs();
+    await gameService.ensureGameInfo();
   })
   .catch((err) => console.error('MongoDB 连接失败', err));
 

--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -28,6 +28,14 @@ async function ensureDefaultClubs() {
   }
 }
 
+async function ensureGameInfo() {
+  const count = await GameInfo.countDocuments();
+  if (count === 0) {
+    await GameInfo.create({});
+    console.log('已初始化游戏信息');
+  }
+}
+
 async function generateItemsFromCategories(type, stage = 'start') {
   const categories = await ItemCategory.find({ type });
   const res = [];
@@ -349,6 +357,7 @@ async function closeArea(pid) {
 
 module.exports = {
   ensureDefaultClubs,
+  ensureGameInfo,
   startGame,
   stopGame,
   mapAreas,

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -3,41 +3,13 @@
     <h2>欢迎来到 DTS</h2>
     <div class="home-container">
       <div class="game-info">
-        <el-row :gutter="20" class="stats">
-          <el-col :span="8">
-            <el-statistic title="游戏版本">
-              <template #default>{{ gameInfo.version ?? '未知' }}</template>
-            </el-statistic>
-          </el-col>
-          <el-col :span="8">
-            <el-statistic
-              :value="currentTime"
-              title="当前时刻"
-              :formatter="formatTime"
-            />
-          </el-col>
-          <el-col :span="8">
-            <el-statistic title="状态">
-              <template #default>{{ gameStatus }}</template>
-            </el-statistic>
-          </el-col>
-        </el-row>
-        <el-row :gutter="20" class="stats">
-          <el-col :span="6">
-            <el-statistic title="已运行">
-              <template #default>{{ runtime }}</template>
-            </el-statistic>
-          </el-col>
-          <el-col :span="6">
-            <el-statistic :value="gameInfo.areanum ?? 0" title="禁区数" />
-          </el-col>
-          <el-col :span="6">
-            <el-statistic :value="gameInfo.alivenum ?? 0" title="存活玩家" />
-          </el-col>
-          <el-col :span="6">
-            <el-statistic :value="gameInfo.deathnum ?? 0" title="死亡总数" />
-          </el-col>
-        </el-row>
+        <p>游戏版本：{{ gameInfo.version ?? '未知' }}</p>
+        <p>当前时刻：{{ formatTime(currentTime) }}</p>
+        <p>状态：{{ gameStatus }}</p>
+        <p>已运行：{{ runtime }}</p>
+        <p>禁区数：{{ gameInfo.areanum ?? '无法获取' }}</p>
+        <p>存活玩家：{{ gameInfo.alivenum ?? '无法获取' }}</p>
+        <p>死亡总数：{{ gameInfo.deathnum ?? '无法获取' }}</p>
         <div class="btn-group">
           <el-button size="small" type="primary" @click="manualStart">手动开始游戏</el-button>
           <el-button size="small" type="danger" @click="manualStop" style="margin-left: 8px">手动关闭游戏</el-button>
@@ -249,9 +221,6 @@ async function logout() {
 }
 .game-info {
   margin-bottom: 20px;
-}
-.stats {
-  margin-bottom: 12px;
 }
 .btn-group {
   margin-top: 10px;


### PR DESCRIPTION
## Summary
- remove `el-statistic` usage from `Home.vue` and restore paragraph layout

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688315373a9483229aeb3b7329e924a6