### PR TITLE
Fix chat records persist between games

### DIFF
--- a/frontend/src/pages/GameOver.vue
+++ b/frontend/src/pages/GameOver.vue
@@ -12,6 +12,8 @@ import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { playerId } from '../store/user'
 import { playerInfo } from '../store/player'
+import { resetLogs } from '../store/logs'
+import { resetChats } from '../store/chat'
 import { getDeadStatus } from '../api'
 import { stateInfo, deathInfo } from '../constants/death'
 
@@ -19,6 +21,8 @@ const router = useRouter()
 const info = playerInfo
 
 async function back() {
+  resetLogs(playerId.value)
+  resetChats(playerId.value)
   playerId.value = ''
   playerInfo.value = null
   router.push('/start')

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -65,7 +65,8 @@ import {
 } from '../api'
 import { user, token, refreshToken, playerId } from '../store/user'
 import { playerInfo } from '../store/player'
-import { logs } from '../store/logs'
+import { logs, resetLogs } from '../store/logs'
+import { resetChats } from '../store/chat'
 
 const gameInfo = ref({})
 const currentTime = ref(Date.now())
@@ -136,9 +137,10 @@ async function manualStop() {
   try {
     await stopGame()
     fetchGameInfo()
+    resetLogs(playerId.value)
+    resetChats(playerId.value)
     playerId.value = ''
     playerInfo.value = null
-    logs.value = []
     localStorage.removeItem('playerId')
   } catch (e) {
     alert(e.response?.data?.msg || '操作失败')
@@ -156,9 +158,10 @@ async function login() {
     localStorage.setItem('token', token.value)
     localStorage.setItem('refreshToken', refreshToken.value)
     // reset player related info
+    resetLogs(playerId.value)
+    resetChats(playerId.value)
     playerId.value = ''
     playerInfo.value = null
-    logs.value = []
     localStorage.removeItem('playerId')
   } catch (e) {
     alert(e.response?.data?.msg || '登录失败')
@@ -175,9 +178,10 @@ async function register() {
     localStorage.setItem('user', user.value)
     localStorage.setItem('token', token.value)
     localStorage.setItem('refreshToken', refreshToken.value)
+    resetLogs(playerId.value)
+    resetChats(playerId.value)
     playerId.value = ''
     playerInfo.value = null
-    logs.value = []
     localStorage.removeItem('playerId')
   } catch (e) {
     alert(e.response?.data?.msg || '注册失败')
@@ -194,9 +198,10 @@ async function logout() {
   user.value = ''
   token.value = ''
   refreshToken.value = ''
+  resetLogs(playerId.value)
+  resetChats(playerId.value)
   playerId.value = ''
   playerInfo.value = null
-  logs.value = []
   localStorage.removeItem('user')
   localStorage.removeItem('token')
   localStorage.removeItem('refreshToken')

--- a/frontend/src/pages/Start.vue
+++ b/frontend/src/pages/Start.vue
@@ -14,7 +14,8 @@ import { useRouter } from 'vue-router'
 import { enterGame, getStatus, getDeadStatus, getClubs } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo } from '../store/player'
-import { logs } from '../store/logs'
+import { logs, resetLogs } from '../store/logs'
+import { resetChats } from '../store/chat'
 
 const router = useRouter()
 const clubs = ref([])
@@ -22,18 +23,20 @@ const selected = ref()
 
 async function start() {
   try {
+    const oldPid = playerId.value
+    resetLogs(oldPid)
+    resetChats(oldPid)
+    playerId.value = ''
     const { data } = await enterGame({ club: selected.value })
     playerId.value = data.pid
     try {
       const status = await getStatus(data.pid)
       playerInfo.value = status.data
-      logs.value = []
       router.push('/game')
     } catch (err) {
       if (err.response?.data?.msg === '你已经死亡') {
         const res = await getDeadStatus(data.pid)
         playerInfo.value = res.data
-        logs.value = []
         router.push('/gameover')
       } else {
         throw err

--- a/frontend/src/store/chat.js
+++ b/frontend/src/store/chat.js
@@ -33,3 +33,12 @@ watch(
 export function addChat(msg) {
   if (msg) chats.value.push(msg);
 }
+
+export function resetChats(pid = playerId.value) {
+  if (pid) {
+    localStorage.removeItem(`chats_${pid}`);
+  }
+  chats.value = [];
+}
+
+export { loadChats };

--- a/frontend/src/store/logs.js
+++ b/frontend/src/store/logs.js
@@ -33,4 +33,11 @@ watch(
   { deep: true },
 );
 
+export function resetLogs(pid = playerId.value) {
+  if (pid) {
+    localStorage.removeItem(`logs_${pid}`);
+  }
+  logs.value = [];
+}
+
 export { loadLogs };


### PR DESCRIPTION
## Summary
- reset chat and log caches when leaving or starting new games
- add helper functions `resetChats` and `resetLogs`
- clear cached data on login/logout and manual stop

## Testing
- `npm run lint` (frontend) *(fails: Missing script)*
- `npm run lint` (backend) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688318de3f3c8322bab0d039262b3b46