### PR TITLE
Add latest action log card on inventory panel

### DIFF
--- a/frontend/src/components/InventoryPanel.vue
+++ b/frontend/src/components/InventoryPanel.vue
@@ -1,6 +1,13 @@
 <template>
   <div>
     <div v-if="info">
+      <el-card
+        v-if="latestLog"
+        class="card-section latest-log-card"
+        shadow="never"
+      >
+        <div v-html="latestLog" />
+      </el-card>
       <h4 style="margin-top:10px">物品栏</h4>
       <el-table :data="items" style="width:100%">
         <el-table-column prop="name" label="物品" />
@@ -38,7 +45,12 @@
 import { computed, ref } from 'vue'
 import { playerInfo as info } from '../store/player'
 import { playerId } from '../store/user'
+import { logs } from '../store/logs'
 import { equipItem, useItem, dropItem } from '../api'
+
+const props = defineProps({
+  latestLog: String,
+})
 
 function getType(kind) {
   if (!kind) return ''
@@ -60,6 +72,12 @@ function isEquip(kind) {
 
 const dropVisible = ref(false)
 const dropIndex = ref(0)
+
+function addLog(message) {
+  if (message) {
+    logs.value.unshift(message)
+  }
+}
 
 const items = computed(() => {
   const res = []
@@ -85,6 +103,7 @@ function equip(index) {
   if (!playerId.value) return
   equipItem(playerId.value, index).then(({ data }) => {
     info.value = data.player
+    addLog(data.msg)
   }).catch(e => {
     const msg = e.response?.data?.msg
     alert(msg || '装备失败')
@@ -95,6 +114,7 @@ function useIt(index) {
   if (!playerId.value) return
   useItem(playerId.value, index).then(({ data }) => {
     info.value = data.player
+    addLog(data.msg)
   }).catch(e => {
     const msg = e.response?.data?.msg
     alert(msg || '使用失败')
@@ -111,6 +131,7 @@ function confirmDrop() {
   if (!playerId.value) return
   dropItem(playerId.value, dropIndex.value).then(({ data }) => {
     info.value = data.player
+    addLog(data.msg)
     dropVisible.value = false
   }).catch(e => {
     const msg = e.response?.data?.msg
@@ -118,3 +139,10 @@ function confirmDrop() {
   })
 }
 </script>
+
+<style scoped>
+.latest-log-card {
+  margin-bottom: 10px;
+  background: #fdfdfd;
+}
+</style>

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -46,10 +46,8 @@
           @close="closeReplaceDialog"
         />
 
-        <p v-if="searchMsg" class="search-msg" v-html="searchMsg" />
-
         <!-- 背包面板 -->
-        <InventoryPanel />
+        <InventoryPanel :latest-log="latestLog" />
         <AreaButtons :areas="places" @move="doMoveTo" />
       </div>
     </div>
@@ -86,7 +84,6 @@ let chatTimer = null
 const lastCid = ref(0)
 const enemy = ref(null)
 const lootItems = ref(null)
-const searchMsg = ref('')
 
 async function refreshMapAreas() {
   try {
@@ -164,7 +161,7 @@ const bagItems = computed(() => {
   return res
 })
 
-const recentLogs = computed(() => logs.value.slice(0, 2))
+const latestLog = computed(() => logs.value[0] || '')
 
 function addLog(message) {
   if (message) {
@@ -258,7 +255,6 @@ onUnmounted(() => {
 async function unequip(field) {
   if (!playerId.value) return
   stopRestTimer()
-  searchMsg.value = ''
   try {
     const { data } = await unequipItem(playerId.value, field)
     info.value = data.player
@@ -271,7 +267,6 @@ async function unequip(field) {
 async function dropEquipItem(field) {
   if (!playerId.value) return
   stopRestTimer()
-  searchMsg.value = ''
   try {
     const { data } = await dropEquip(playerId.value, field)
     info.value = data.player
@@ -284,7 +279,6 @@ async function dropEquipItem(field) {
 async function doMoveTo(pid) {
   if (!playerId.value) return
   stopRestTimer()
-  searchMsg.value = ''
   try {
     const { data } = await move(playerId.value, pid)
     info.value = data.player
@@ -300,7 +294,6 @@ async function doMoveTo(pid) {
 async function doSearch() {
   if (!playerId.value) return
   stopRestTimer()
-  searchMsg.value = ''
   try {
     const { data } = await search(playerId.value)
     info.value = data.player
@@ -308,7 +301,6 @@ async function doSearch() {
     enemy.value = data.enemy || null
     lootItems.value = null
     await refreshMapAreas()
-    searchMsg.value = data.log
     addLog(data.log)
     checkDeath()
   } catch (e) {
@@ -318,7 +310,6 @@ async function doSearch() {
 
 async function doRest() {
   if (!playerId.value) return
-  searchMsg.value = ''
   try {
     const { data } = await rest(playerId.value)
     info.value = data.player
@@ -336,7 +327,6 @@ async function doRest() {
 async function pickFound() {
   if (!playerId.value || !foundItem.value) return
   stopRestTimer()
-  searchMsg.value = ''
   try {
     const { data } = await pickItem(playerId.value, foundItem.value._id)
     info.value = data.player
@@ -358,7 +348,6 @@ async function pickFound() {
 async function equipFound() {
   if (!playerId.value || !foundItem.value) return
   stopRestTimer()
-  searchMsg.value = ''
   try {
     const { data } = await pickEquip(playerId.value, foundItem.value._id)
     info.value = data.player
@@ -374,7 +363,6 @@ async function equipFound() {
 async function doReplace(index) {
   if (!playerId.value || replaceItemId === null) return
   stopRestTimer()
-  searchMsg.value = ''
   try {
     const { data } = await pickReplace(playerId.value, replaceItemId, index)
     info.value = data.player
@@ -393,13 +381,11 @@ function closeReplaceDialog() {
   replaceVisible.value = false
   replaceItemId = null
   foundItem.value = null
-  searchMsg.value = ''
 }
 
 async function doAttack() {
   if (!playerId.value || !enemy.value) return
   stopRestTimer()
-  searchMsg.value = ''
   try {
     const { data } = await attack(playerId.value, enemy.value.pid)
     info.value = data.player
@@ -416,7 +402,6 @@ async function doAttack() {
 
 async function doLoot(slot) {
   if (!playerId.value || !enemy.value) return
-  searchMsg.value = ''
   try {
     const { data } = await lootCorpse(playerId.value, enemy.value.pid, slot)
     info.value = data.player
@@ -481,9 +466,5 @@ function sendChatMsg(text) {
 .label {
   font-weight: bold;
   margin-right: 8px;
-}
-.search-msg {
-  margin: 10px 0;
-  color: #409EFF;
 }
 </style>


### PR DESCRIPTION
## Summary
- show latest log message above inventory list
- propagate action logs from item actions
- remove old search message display and use log store instead

## Testing
- `npm run lint` in `frontend` *(fails: Missing script)*
- `npm run lint` in `backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68831d4383f08322a16e641e9101206d