### PR TITLE
Fix movement logging and close battle panel after kill

### DIFF
--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -283,7 +283,9 @@ async function doMoveTo(pid) {
     const { data } = await move(playerId.value, pid)
     info.value = data.player
     await refreshMapAreas()
-    addLog(data.msg)
+    addLog(data.log)
+    foundItem.value = data.item || null
+    enemy.value = data.enemy || null
     lootItems.value = null
     checkDeath()
   } catch (e) {
@@ -393,7 +395,11 @@ async function doAttack() {
     if (data.loot) {
       lootItems.value = data.loot
     }
-    enemy.value = data.enemy || null
+    if (data.enemy && data.enemy.hp > 0) {
+      enemy.value = data.enemy
+    } else {
+      enemy.value = null
+    }
     checkDeath()
   } catch (e) {
     alert(e.response?.data?.msg || '攻击失败')


### PR DESCRIPTION
## Summary
- improve map movement handling
- close battle info after enemy is defeated

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_68831fd805e48322887ec1fab64556b0