### PR TITLE
Add item refresh admin option and fix death count

### DIFF
--- a/backend/src/controllers/gameController.js
+++ b/backend/src/controllers/gameController.js
@@ -8,11 +8,11 @@ exports.getInfo = async (req, res) => {
     await gameService.checkGameOver();
     const info = await GameInfo.findOne();
     if (info) {
-      const [validnum, alivenum, deathnum] = await Promise.all([
+      const [validnum, alivenum] = await Promise.all([
         Player.countDocuments({ type: 0 }),
         Player.countDocuments({ type: 0, hp: { $gt: 0 } }),
-        Player.countDocuments({ type: 0, hp: { $lte: 0 } }),
       ]);
+      const deathnum = validnum - alivenum;
       info.validnum = validnum;
       info.alivenum = alivenum;
       info.deathnum = deathnum;

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -73,7 +73,7 @@ const collections = [
   { label: '聊天', value: 'chats' },
   { label: '地图物品', value: 'mapitems' },
   { label: '陷阱', value: 'maptraps' },
-  { label: '物品类别', value: 'itemcategories' },
+  { label: '物品刷新', value: 'itemcategories' },
   { label: '新闻', value: 'newsinfos' },
   { label: '房间监听', value: 'roomlisteners' },
   { label: '历史记录', value: 'histories' },


### PR DESCRIPTION
## Summary
- fix death count by calculating from total players minus alive
- integrate item refresh management directly on Admin page
- remove unused ItemCategoryAdmin page and route

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68831db109c08322875d5827d992547d