### PR TITLE
Enable admin import of map item categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ mongoimport --db dts --collection mapitems --file ../data/mapitems.json --jsonAr
 mongoimport --db dts --collection itemcategories --file ../data/itemCategories.json --jsonArray
 ```
 `itemCategories.json` 示范了物品刷新阶段（start、ban2、ban4）对应的道具列表，可在后台管理界面调整。
-`mapitems.json` 内同样带有 `stage` 字段，记录各阶段默认刷新到地图上的道具。
+`mapitems.json` 内同样带有 `stage` 字段，记录各阶段默认刷新到地图上的道具。若未导入该集合，可通过 `POST /api/admin/itemcategories/import-default` 从 `mapitems.json` 生成默认记录。
 
 也可以在 `mongo` shell 中执行 `data/initData.js` 脚本一次完成导入：
 

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -4,6 +4,7 @@ const auth = require('../middlewares/auth');
 const checkAdmin = require('../middlewares/admin');
 const fieldsMeta = require('../fieldsMeta');
 const gameService = require('../services/gameService');
+const itemCategoryService = require('../services/itemCategoryService');
 
 const models = {
   players: require('../models/Player'),
@@ -158,6 +159,16 @@ router.delete('/:collection/:id', async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ msg: '删除失败' });
+  }
+});
+
+router.post('/itemcategories/import-default', async (req, res) => {
+  try {
+    const count = await itemCategoryService.importFromMapItems();
+    res.json({ msg: `已导入 ${count} 个类别` });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ msg: '导入失败' });
   }
 });
 

--- a/backend/src/services/itemCategoryService.js
+++ b/backend/src/services/itemCategoryService.js
@@ -1,0 +1,39 @@
+const ItemCategory = require('../models/ItemCategory');
+const Item = require('../models/Item');
+const fs = require('fs');
+const path = require('path');
+
+async function importFromMapItems() {
+  const file = path.join(__dirname, '../../../data/mapitems.json');
+  if (!fs.existsSync(file)) throw new Error('mapitems.json not found');
+  const raw = JSON.parse(fs.readFileSync(file));
+  const items = await Item.find({}, 'id name');
+  const nameMap = {};
+  items.forEach((it) => {
+    if (nameMap[it.name] === undefined) nameMap[it.name] = it.id;
+  });
+  const catMap = {};
+  for (const m of raw) {
+    const stage = m.stage || 'start';
+    if (!catMap[stage]) catMap[stage] = { name: `默认${stage}`, type: 'mapitem', items: [] };
+    const itemId = nameMap[m.itm];
+    if (!itemId) continue;
+    catMap[stage].items.push({
+      itemId,
+      pls: m.pls || 0,
+      count: 1,
+      itmk: m.itmk,
+      itme: m.itme,
+      itms: m.itms,
+      itmsk: m.itmsk,
+      stage,
+    });
+  }
+  const list = Object.values(catMap);
+  if (!list.length) return 0;
+  await ItemCategory.deleteMany({});
+  await ItemCategory.insertMany(list);
+  return list.length;
+}
+
+module.exports = { importFromMapItems };

--- a/mogoDB.md/itemcategories.md
+++ b/mogoDB.md/itemcategories.md
@@ -26,3 +26,6 @@ db.itemcategories.createIndex({ name: 1 });
 ```bash
 mongoimport --db dts --collection itemcategories --file ../data/itemCategories.json --jsonArray
 ```
+
+若未预先导入，可在后台通过接口 `/api/admin/itemcategories/import-default` 从
+`mapitems.json` 生成默认记录，便于在管理界面进行增删改查。


### PR DESCRIPTION
## Summary
- add itemCategoryService with conversion from `mapitems.json`
- expose POST `/api/admin/itemcategories/import-default` for admins
- document import endpoint in README and MongoDB docs

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in frontend (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_688322e289808322893622ab4d8d16d0