### PR TITLE
更新地图资源管理页面，支持编辑NPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,14 @@ npm run lint     # 代码规范检查
 - **DELETE `/api/admin/:collection/:id`**：删除指定文档。
 - **GET `/api/admin/maps`**：查看各地图区域的在线玩家。
 
+## 更新记录
+
+### 2025-07-29
+
+- 新增“地图资源”后台管理页，可树形管理各区域的地图物品、陷阱、刷新表、商店物品及 NPC
+- `itemcategories` 集合增加 `tables` 字段，可引用其他刷新表
+- `gameService` 中生成地图物品与陷阱的逻辑更新，递归解析 `tables` 引用
+
 ---
 
 ## 参考/致谢

--- a/backend/src/fieldsMeta.js
+++ b/backend/src/fieldsMeta.js
@@ -66,7 +66,12 @@ module.exports = {
     { name: 'time', label: '时间戳', type: 'number' },
   ],
   mapitems: [
-    { name: 'stage', label: '刷新阶段', type: 'select', options: ['start', 'ban2', 'ban4'] },
+    {
+      name: 'stage',
+      label: '刷新阶段',
+      type: 'select',
+      options: ['start', 'ban2', 'ban4'],
+    },
     { name: 'itm', label: '道具名', type: 'text' },
     { name: 'itmk', label: '种类', type: 'text' },
     { name: 'itme', label: '效果值', type: 'number' },
@@ -147,7 +152,12 @@ module.exports = {
       type: 'select',
       options: ['mapitem', 'maptrap'],
     },
-    { name: 'items', label: '条目列表(JSON)', type: 'text' },
+    {
+      name: 'tables',
+      label: '使用刷新表',
+      type: 'multiselect',
+      options: ['mapitem', 'mapitem_i8', 'mapitem_i9'],
+    },
   ],
   maps: [
     { name: 'pls', label: '区域ID', type: 'number' },

--- a/backend/src/models/ItemCategory.js
+++ b/backend/src/models/ItemCategory.js
@@ -18,6 +18,8 @@ const itemCategorySchema = new mongoose.Schema({
   name: { type: String, default: '' },
   type: { type: String, default: 'mapitem' }, // mapitem or maptrap
   items: [itemEntrySchema],
+  // 可引用其他刷新表名称，后台可多选
+  tables: { type: [String], default: [] },
 });
 
 module.exports = mongoose.model('ItemCategory', itemCategorySchema);

--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -38,29 +38,44 @@ async function ensureGameInfo() {
 
 async function generateItemsFromCategories(type, stage = 'start') {
   const categories = await ItemCategory.find({ type });
+  const map = {};
+  categories.forEach((c) => {
+    map[c.name] = c;
+  });
   const res = [];
   let id = 1;
-  for (const c of categories) {
-    for (const e of c.items || []) {
+  const visited = new Set();
+
+  function process(cat) {
+    if (!cat || visited.has(cat.name)) return;
+    visited.add(cat.name);
+    for (const e of cat.items || []) {
       if (e.stage && e.stage !== stage) continue;
-      const base = await Item.findOne({ id: e.itemId });
-      if (!base) continue;
-      const cnt = e.count || 1;
-      for (let i = 0; i < cnt; i++) {
-        const obj = {
-          itm: base.name,
-          itmk: e.itmk || base.kind,
-          itme: e.itme !== undefined ? e.itme : base.effect,
-          itms: e.itms !== undefined ? e.itms : base.dur,
-          itmsk: e.itmsk || base.skill,
-          pls: e.pls || 0,
-        };
-        if (type === 'mapitem') obj.iid = id++;
-        else obj.tid = id++;
-        res.push(obj);
-      }
+      const base = Item.findOne({ id: e.itemId });
+      promises.push(base.then((b) => {
+        if (!b) return;
+        const cnt = e.count || 1;
+        for (let i = 0; i < cnt; i++) {
+          const obj = {
+            itm: b.name,
+            itmk: e.itmk || b.kind,
+            itme: e.itme !== undefined ? e.itme : b.effect,
+            itms: e.itms !== undefined ? e.itms : b.dur,
+            itmsk: e.itmsk || b.skill,
+            pls: e.pls || 0,
+          };
+          if (type === 'mapitem') obj.iid = id++;
+          else obj.tid = id++;
+          res.push(obj);
+        }
+      }));
     }
+    (cat.tables || []).forEach((n) => process(map[n]));
   }
+
+  const promises = [];
+  categories.forEach(process);
+  await Promise.all(promises);
   return res;
 }
 

--- a/data/itemCategories.json
+++ b/data/itemCategories.json
@@ -2,6 +2,7 @@
   {
     "name": "默认地图掉落",
     "type": "mapitem",
+    "tables": [],
     "items": [
       { "itemId": 1, "pls": 1, "count": 2, "stage": "start" },
       { "itemId": 2, "pls": 2, "count": 3, "stage": "ban2" }

--- a/frontend/src/components/FormDialog.vue
+++ b/frontend/src/components/FormDialog.vue
@@ -1,10 +1,22 @@
 <template>
-  <el-dialog v-model="visible" :title="title" width="600px" @close="$emit('close')">
+  <el-dialog
+    v-model="visible"
+    :title="title"
+    width="600px"
+    @close="$emit('close')"
+  >
     <el-form label-width="80px">
       <el-form-item v-for="f in fields" :key="f.name" :label="f.label">
-        <el-input v-if="f.type==='text'" v-model="form[f.name]" />
-        <el-input-number v-else-if="f.type==='number'" v-model="form[f.name]" />
-        <el-select v-else-if="f.type==='select'" v-model="form[f.name]">
+        <el-input v-if="f.type === 'text'" v-model="form[f.name]" />
+        <el-input-number
+          v-else-if="f.type === 'number'"
+          v-model="form[f.name]"
+        />
+        <el-select
+          v-else-if="f.type === 'select' || f.type === 'multiselect'"
+          v-model="form[f.name]"
+          :multiple="f.type === 'multiselect'"
+        >
           <el-option
             v-for="op in f.options"
             :key="typeof op === 'object' ? op.value : op"
@@ -23,16 +35,16 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed } from 'vue';
 const props = defineProps({
   modelValue: Boolean,
   title: String,
   fields: { type: Array, default: () => [] },
-  form: { type: Object, default: () => ({}) }
-})
-const emit = defineEmits(['update:modelValue','save','close'])
+  form: { type: Object, default: () => ({}) },
+});
+const emit = defineEmits(['update:modelValue', 'save', 'close']);
 const visible = computed({
   get: () => props.modelValue,
-  set: v => emit('update:modelValue', v)
-})
+  set: (v) => emit('update:modelValue', v),
+});
 </script>

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -49,6 +49,7 @@
 
 <script setup>
 import { ref, watch, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import TablePanel from '../components/TablePanel.vue'
 import FormDialog from '../components/FormDialog.vue'
 import {
@@ -65,16 +66,14 @@ import {
 import { mapAreas } from '../store/map'
 import { trapTypeText } from '../constants/enums'
 
+const router = useRouter()
 const collections = [
   { label: '玩家', value: 'players' },
   { label: 'NPC', value: 'npcs' },
-  { label: '商店物品', value: 'shopitems' },
   { label: '物品表', value: 'items' },
   { label: '日志', value: 'logs' },
   { label: '聊天', value: 'chats' },
-  { label: '地图物品', value: 'mapitems' },
-  { label: '陷阱', value: 'maptraps' },
-  { label: '物品刷新', value: 'itemcategories' },
+  { label: '地图资源', value: 'mapresources' },
   { label: '新闻', value: 'newsinfos' },
   { label: '房间监听', value: 'roomlisteners' },
   { label: '历史记录', value: 'histories' },
@@ -104,6 +103,10 @@ const isMapAreas = computed(() => collection.value === 'mapareas')
 const areaFilter = ref(-1)
 
 watch(collection, () => {
+  if (collection.value === 'mapresources') {
+    router.push('/admin/mapresources')
+    return
+  }
   skip.value = 0
   allLoaded.value = false
   items.value = []

--- a/frontend/src/pages/ItemCategoryAdmin.vue
+++ b/frontend/src/pages/ItemCategoryAdmin.vue
@@ -1,22 +1,43 @@
 <template>
   <div class="page">
     <h2>物品刷新管理</h2>
-    <el-button type="primary" size="small" @click="openCreateCategory">新建类别</el-button>
-    <el-row :gutter="20" style="margin-top:10px">
+    <el-button type="primary" size="small" @click="openCreateCategory"
+      >新建类别</el-button
+    >
+    <el-row :gutter="20" style="margin-top: 10px">
       <el-col v-for="cat in categories" :key="cat._id" :span="8">
         <el-card shadow="hover">
           <template #header>
             <span>{{ cat.name }}</span>
-            <div style="float:right">
-              <el-button text size="small" @click="openEditCategory(cat)">编辑</el-button>
-              <el-button text size="small" type="danger" @click="removeCategory(cat)">删除</el-button>
+            <div style="float: right">
+              <el-button text size="small" @click="openEditCategory(cat)"
+                >编辑</el-button
+              >
+              <el-button
+                text
+                size="small"
+                type="danger"
+                @click="removeCategory(cat)"
+                >删除</el-button
+              >
             </div>
           </template>
           <el-tabs v-model="tabs[cat._id]">
-            <el-tab-pane v-for="s in stageOptions" :key="s.value" :label="s.label" :name="s.value">
-              <el-table :data="filterStage(cat.items, s.value)" size="small" style="width:100%">
+            <el-tab-pane
+              v-for="s in stageOptions"
+              :key="s.value"
+              :label="s.label"
+              :name="s.value"
+            >
+              <el-table
+                :data="filterStage(cat.items, s.value)"
+                size="small"
+                style="width: 100%"
+              >
                 <el-table-column prop="itemId" label="物品">
-                  <template #default="{ row }">{{ itemName(row.itemId) }}</template>
+                  <template #default="{ row }">{{
+                    itemName(row.itemId)
+                  }}</template>
                 </el-table-column>
                 <el-table-column prop="pls" label="区域" width="70" />
                 <el-table-column prop="count" label="数量" width="60" />
@@ -26,13 +47,23 @@
                 <el-table-column prop="itmsk" label="itmsk" width="80" />
                 <el-table-column label="操作" width="120">
                   <template #default="{ row }">
-                    <el-button text size="small" @click="openEditItem(cat, row)">编辑</el-button>
-                    <el-button text size="small" type="danger" @click="removeItem(cat, row)">删除</el-button>
+                    <el-button text size="small" @click="openEditItem(cat, row)"
+                      >编辑</el-button
+                    >
+                    <el-button
+                      text
+                      size="small"
+                      type="danger"
+                      @click="removeItem(cat, row)"
+                      >删除</el-button
+                    >
                   </template>
                 </el-table-column>
               </el-table>
-              <div style="margin-top:6px;text-align:right">
-                <el-button size="small" @click="openCreateItem(cat, s.value)">添加条目</el-button>
+              <div style="margin-top: 6px; text-align: right">
+                <el-button size="small" @click="openCreateItem(cat, s.value)"
+                  >添加条目</el-button
+                >
               </div>
             </el-tab-pane>
           </el-tabs>
@@ -45,154 +76,191 @@
       :fields="dialogFields"
       :form="formData"
       @save="saveDialog"
-      @close="dialogVisible=false"
+      @close="dialogVisible = false"
     />
   </div>
 </template>
 
 <script setup>
-import { ref, reactive, onMounted, watchEffect } from 'vue'
-import { adminList, adminCreate, adminUpdate, adminDelete } from '../api'
-import FormDialog from '../components/FormDialog.vue'
+import { ref, reactive, onMounted, watchEffect, computed } from 'vue';
+import { adminList, adminCreate, adminUpdate, adminDelete } from '../api';
+import FormDialog from '../components/FormDialog.vue';
 
-const categories = ref([])
-const items = ref([])
-const tabs = reactive({})
+const categories = ref([]);
+const items = ref([]);
+const categoryOptions = computed(() =>
+  categories.value.map((c) => ({ label: c.name, value: c.name })),
+);
+const tabs = reactive({});
 const stageOptions = [
   { label: 'start', value: 'start' },
   { label: 'ban2', value: 'ban2' },
   { label: 'ban4', value: 'ban4' },
-]
+];
 
-const dialogVisible = ref(false)
-const dialogTitle = ref('')
-const dialogFields = ref([])
-const formData = ref({})
-let editCategoryId = ''
-let editItemIndex = -1
+const dialogVisible = ref(false);
+const dialogTitle = ref('');
+const dialogFields = ref([]);
+const formData = ref({});
+let editCategoryId = '';
+let editItemIndex = -1;
 
 onMounted(() => {
-  fetchCategories()
-  fetchItems()
-})
+  fetchCategories();
+  fetchItems();
+});
 
 async function fetchCategories() {
   try {
-    const { data } = await adminList('itemcategories', { limit: 1000 })
-    categories.value = data
-    data.forEach(c => { if (!tabs[c._id]) tabs[c._id] = 'start' })
+    const { data } = await adminList('itemcategories', { limit: 1000 });
+    categories.value = data;
+    data.forEach((c) => {
+      if (!tabs[c._id]) tabs[c._id] = 'start';
+    });
   } catch {}
 }
 
 async function fetchItems() {
   try {
-    const { data } = await adminList('items', { skip: 0, limit: 1000 })
-    items.value = data
+    const { data } = await adminList('items', { skip: 0, limit: 1000 });
+    items.value = data;
   } catch {}
 }
 
 function itemName(id) {
-  const it = items.value.find(i => i.id === id)
-  return it ? it.name : id
+  const it = items.value.find((i) => i.id === id);
+  return it ? it.name : id;
 }
 
 function filterStage(list, stage) {
-  return (list || []).filter(it => (it.stage || 'start') === stage)
+  return (list || []).filter((it) => (it.stage || 'start') === stage);
 }
 
 function openCreateCategory() {
-  dialogTitle.value = '新建类别'
+  dialogTitle.value = '新建类别';
   dialogFields.value = [
     { name: 'name', label: '类别名称', type: 'text' },
-    { name: 'type', label: '类别类型', type: 'select', options: ['mapitem', 'maptrap'] },
-  ]
-  formData.value = { name: '', type: 'mapitem' }
-  editCategoryId = ''
-  dialogVisible.value = true
+    {
+      name: 'type',
+      label: '类别类型',
+      type: 'select',
+      options: ['mapitem', 'maptrap'],
+    },
+    {
+      name: 'tables',
+      label: '使用刷新表',
+      type: 'multiselect',
+      options: categoryOptions.value,
+    },
+  ];
+  formData.value = { name: '', type: 'mapitem', tables: [] };
+  editCategoryId = '';
+  dialogVisible.value = true;
 }
 
 function openEditCategory(c) {
-  dialogTitle.value = '编辑类别'
+  dialogTitle.value = '编辑类别';
   dialogFields.value = [
     { name: 'name', label: '类别名称', type: 'text' },
-    { name: 'type', label: '类别类型', type: 'select', options: ['mapitem', 'maptrap'] },
-  ]
-  formData.value = { name: c.name, type: c.type }
-  editCategoryId = c._id
-  dialogVisible.value = true
+    {
+      name: 'type',
+      label: '类别类型',
+      type: 'select',
+      options: ['mapitem', 'maptrap'],
+    },
+    {
+      name: 'tables',
+      label: '使用刷新表',
+      type: 'multiselect',
+      options: categoryOptions.value,
+    },
+  ];
+  formData.value = { name: c.name, type: c.type, tables: c.tables || [] };
+  editCategoryId = c._id;
+  dialogVisible.value = true;
 }
 
 function openCreateItem(cat, stage) {
-  dialogTitle.value = '添加条目'
-  dialogFields.value = entryFields
-  formData.value = { itemId: items.value[0]?.id || 0, pls: 0, count: 1, stage }
-  editCategoryId = cat._id
-  editItemIndex = -1
-  dialogVisible.value = true
+  dialogTitle.value = '添加条目';
+  dialogFields.value = entryFields;
+  formData.value = { itemId: items.value[0]?.id || 0, pls: 0, count: 1, stage };
+  editCategoryId = cat._id;
+  editItemIndex = -1;
+  dialogVisible.value = true;
 }
 
 function openEditItem(cat, row) {
-  dialogTitle.value = '编辑条目'
-  dialogFields.value = entryFields
-  formData.value = { ...row }
-  editCategoryId = cat._id
-  editItemIndex = cat.items.indexOf(row)
-  dialogVisible.value = true
+  dialogTitle.value = '编辑条目';
+  dialogFields.value = entryFields;
+  formData.value = { ...row };
+  editCategoryId = cat._id;
+  editItemIndex = cat.items.indexOf(row);
+  dialogVisible.value = true;
 }
 
 const entryFields = [
   { name: 'itemId', label: '物品', type: 'select', options: [] },
   { name: 'pls', label: '区域', type: 'number' },
   { name: 'count', label: '数量', type: 'number' },
-  { name: 'stage', label: '阶段', type: 'select', options: ['start', 'ban2', 'ban4'] },
+  {
+    name: 'stage',
+    label: '阶段',
+    type: 'select',
+    options: ['start', 'ban2', 'ban4'],
+  },
   { name: 'itmk', label: 'itmk', type: 'text' },
   { name: 'itme', label: 'itme', type: 'number' },
   { name: 'itms', label: 'itms', type: 'text' },
   { name: 'itmsk', label: 'itmsk', type: 'text' },
-]
+];
 
 function updateEntryOptions() {
-  entryFields[0].options = items.value.map(it => ({ label: it.name, value: it.id }))
+  entryFields[0].options = items.value.map((it) => ({
+    label: it.name,
+    value: it.id,
+  }));
 }
 
-watchEffect(updateEntryOptions)
+watchEffect(updateEntryOptions);
 
 async function saveDialog() {
   if (dialogFields.value[0].name === 'itemId') {
-    await saveItem()
+    await saveItem();
   } else {
-    await saveCategory()
+    await saveCategory();
   }
 }
 
 async function saveCategory() {
-  if (editCategoryId) await adminUpdate('itemcategories', editCategoryId, formData.value)
-  else await adminCreate('itemcategories', { ...formData.value, items: [] })
-  dialogVisible.value = false
-  fetchCategories()
+  if (editCategoryId)
+    await adminUpdate('itemcategories', editCategoryId, formData.value);
+  else await adminCreate('itemcategories', { ...formData.value, items: [] });
+  dialogVisible.value = false;
+  fetchCategories();
 }
 
 async function saveItem() {
-  const cat = categories.value.find(c => c._id === editCategoryId)
-  if (!cat) return
-  if (editItemIndex >= 0) cat.items.splice(editItemIndex, 1, { ...formData.value })
-  else cat.items.push({ ...formData.value })
-  await adminUpdate('itemcategories', cat._id, { items: cat.items })
-  dialogVisible.value = false
-  fetchCategories()
+  const cat = categories.value.find((c) => c._id === editCategoryId);
+  if (!cat) return;
+  if (editItemIndex >= 0)
+    cat.items.splice(editItemIndex, 1, { ...formData.value });
+  else cat.items.push({ ...formData.value });
+  await adminUpdate('itemcategories', cat._id, { items: cat.items });
+  dialogVisible.value = false;
+  fetchCategories();
 }
 
 async function removeCategory(cat) {
-  if (!confirm('确定删除该类别？')) return
-  await adminDelete('itemcategories', cat._id)
-  fetchCategories()
+  if (!confirm('确定删除该类别？')) return;
+  await adminDelete('itemcategories', cat._id);
+  fetchCategories();
 }
 
 async function removeItem(cat, row) {
-  if (!confirm('确定删除该条目？')) return
-  cat.items = cat.items.filter(i => i !== row)
-  await adminUpdate('itemcategories', cat._id, { items: cat.items })
-  fetchCategories()
+  if (!confirm('确定删除该条目？')) return;
+  cat.items = cat.items.filter((i) => i !== row);
+  await adminUpdate('itemcategories', cat._id, { items: cat.items });
+  fetchCategories();
 }
 </script>
 

--- a/frontend/src/pages/MapResourceAdmin.vue
+++ b/frontend/src/pages/MapResourceAdmin.vue
@@ -1,0 +1,312 @@
+<template>
+  <div class="page">
+    <h2>地图资源管理</h2>
+    <el-tree
+      :data="treeData"
+      :props="treeProps"
+      node-key="id"
+      default-expand-all
+      @node-click="handleNodeClick"
+    >
+      <template #default="{ node, data }">
+        <span>{{ node.label }}</span>
+        <span v-if="data.type === 'shopitem'"> x{{ data.num }}</span>
+        <el-button
+          v-if="['itemGroup','trapGroup','shopGroup','npcGroup'].includes(data.type)"
+          text
+          size="small"
+          @click.stop="openCreate(data)"
+          >添加</el-button
+        >
+        <el-button
+          v-if="['mapitem','maptrap','shopitem','npc','area'].includes(data.type)"
+          text
+          size="small"
+          @click.stop="openEdit(data)"
+          >编辑</el-button
+        >
+        <el-button
+          v-if="['mapitem','maptrap','shopitem','npc'].includes(data.type)"
+          text
+          size="small"
+          type="danger"
+          @click.stop="removeNode(data)"
+          >删除</el-button
+        >
+        <el-button
+          v-if="data.type === 'category'"
+          text
+          size="small"
+          @click.stop="goCategory"
+          >编辑刷新表</el-button
+        >
+      </template>
+    </el-tree>
+    <FormDialog
+      v-model="dialogVisible"
+      :title="dialogTitle"
+      :fields="dialogFields"
+      :form="formData"
+      @save="saveDialog"
+      @close="dialogVisible = false"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import {
+  adminList,
+  adminCreate,
+  adminUpdate,
+  adminDelete,
+  adminFieldMeta,
+} from '../api';
+import FormDialog from '../components/FormDialog.vue';
+
+const router = useRouter();
+const treeData = ref([]);
+const treeProps = { children: 'children', label: 'label' };
+
+const dialogVisible = ref(false);
+const dialogTitle = ref('');
+const dialogFields = ref([]);
+const formData = ref({});
+let editCollection = '';
+let editId = '';
+let currentArea = 0;
+
+onMounted(() => {
+  fetchData();
+});
+
+async function fetchData() {
+  try {
+    const [areasRes, itemsRes, trapsRes, catsRes, shopsRes, npcsRes] = await Promise.all([
+      adminList('mapareas', { limit: 1000 }),
+      adminList('mapitems', { limit: 1000 }),
+      adminList('maptraps', { limit: 1000 }),
+      adminList('itemcategories', { limit: 1000 }),
+      adminList('shopitems', { limit: 1000 }),
+      adminList('npcs', { limit: 1000 }),
+    ]);
+    buildTree(
+      areasRes.data,
+      itemsRes.data,
+      trapsRes.data,
+      catsRes.data,
+      shopsRes.data,
+      npcsRes.data,
+    );
+  } catch {}
+}
+
+function groupBy(list, key) {
+  const m = {};
+  list.forEach((it) => {
+    const v = it[key] || 0;
+    if (!m[v]) m[v] = [];
+    m[v].push(it);
+  });
+  return m;
+}
+
+function buildTree(areas, items, traps, cats, shops, npcs) {
+  const itemByArea = groupBy(items, 'pls');
+  const trapByArea = groupBy(traps, 'pls');
+  const shopByArea = groupBy(shops, 'area');
+  const npcByArea = groupBy(npcs, 'pls');
+  const catByArea = {};
+  cats.forEach((cat) => {
+    (cat.items || []).forEach((e) => {
+      const p = e.pls || 0;
+      if (!catByArea[p]) catByArea[p] = [];
+      if (!catByArea[p].includes(cat)) catByArea[p].push(cat);
+    });
+  });
+  treeData.value = areas.map((a) => {
+    const children = [];
+    const itemsList = (itemByArea[a.pid] || []).map((it) => ({
+      id: it._id,
+      label: it.itm,
+      type: 'mapitem',
+      area: a.pid,
+      data: it,
+    }));
+    if (itemsList.length)
+      children.push({
+        id: `items-${a.pid}`,
+        label: '地图物品',
+        type: 'itemGroup',
+        area: a.pid,
+        children: itemsList,
+      });
+    const trapsList = (trapByArea[a.pid] || []).map((it) => ({
+      id: it._id,
+      label: it.itm,
+      type: 'maptrap',
+      area: a.pid,
+      data: it,
+    }));
+    if (trapsList.length)
+      children.push({
+        id: `traps-${a.pid}`,
+        label: '陷阱',
+        type: 'trapGroup',
+        area: a.pid,
+        children: trapsList,
+      });
+    const catList = (catByArea[a.pid] || []).map((c) => ({
+      id: c._id,
+      label: c.name,
+      type: 'category',
+      area: a.pid,
+      data: c,
+    }));
+    if (catList.length)
+      children.push({
+        id: `cats-${a.pid}`,
+        label: '刷新表',
+        type: 'catGroup',
+        area: a.pid,
+        children: catList,
+      });
+    const shopList = (shopByArea[a.pid] || []).map((s) => ({
+      id: s._id,
+      label: s.item,
+      num: s.num,
+      type: 'shopitem',
+      area: a.pid,
+      data: s,
+    }));
+    if (shopList.length)
+      children.push({
+        id: `shops-${a.pid}`,
+        label: '商店物品',
+        type: 'shopGroup',
+        area: a.pid,
+        children: shopList,
+      });
+    else
+      children.push({
+        id: `shop-${a.pid}`,
+        label: '商店: 无',
+        type: 'info',
+        area: a.pid,
+      });
+    const npcList = (npcByArea[a.pid] || []).map((n) => ({
+      id: n._id,
+      label: `${n.name}(${n.spawnStage})`,
+      type: 'npc',
+      area: a.pid,
+      data: n,
+    }));
+    if (npcList.length)
+      children.push({
+        id: `npcs-${a.pid}`,
+        label: 'NPC',
+        type: 'npcGroup',
+        area: a.pid,
+        children: npcList,
+      });
+    return {
+      id: a._id,
+      label: a.name,
+      type: 'area',
+      area: a.pid,
+      data: a,
+      children,
+    };
+  });
+}
+
+function handleNodeClick(data) {
+  // do nothing
+}
+
+async function openEdit(data) {
+  editCollection = data.type === 'mapitem'
+    ? 'mapitems'
+    : data.type === 'maptrap'
+    ? 'maptraps'
+    : data.type === 'shopitem'
+    ? 'shopitems'
+    : data.type === 'npc'
+    ? 'npcs'
+    : data.type === 'area'
+    ? 'mapareas'
+    : '';
+  editId = data.data._id;
+  currentArea = data.area;
+  const { data: fields } = await adminFieldMeta(editCollection);
+  dialogFields.value = fields;
+  dialogTitle.value = '编辑';
+  formData.value = { ...data.data };
+  dialogVisible.value = true;
+}
+
+async function openCreate(group) {
+  const map = {
+    itemGroup: 'mapitems',
+    trapGroup: 'maptraps',
+    shopGroup: 'shopitems',
+    npcGroup: 'npcs',
+  };
+  const col = map[group.type];
+  if (!col) return;
+  editCollection = col;
+  editId = '';
+  currentArea = group.area;
+  const { data: fields } = await adminFieldMeta(col);
+  dialogFields.value = fields;
+  dialogTitle.value = '新建';
+  formData.value = {};
+  if (col === 'mapitems' || col === 'maptraps' || col === 'npcs')
+    formData.value.pls = group.area;
+  if (col === 'shopitems') formData.value.area = group.area;
+  dialogVisible.value = true;
+}
+
+async function saveDialog() {
+  try {
+    if (editId) {
+      await adminUpdate(editCollection, editId, formData.value);
+    } else {
+      await adminCreate(editCollection, formData.value);
+    }
+    dialogVisible.value = false;
+    fetchData();
+  } catch (e) {
+    alert(e.response?.data?.msg || '保存失败');
+  }
+}
+
+async function removeNode(data) {
+  const map = {
+    mapitem: 'mapitems',
+    maptrap: 'maptraps',
+    shopitem: 'shopitems',
+    npc: 'npcs',
+  };
+  const col = map[data.type];
+  if (!col) return;
+  if (!confirm('确定删除？')) return;
+  try {
+    await adminDelete(col, data.data._id);
+    fetchData();
+  } catch (e) {
+    alert(e.response?.data?.msg || '删除失败');
+  }
+}
+
+function goCategory() {
+  router.push('/admin/itemcategories');
+}
+</script>
+
+<style scoped>
+.page {
+  padding: 20px;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -10,6 +10,7 @@ import Help from '../pages/Help.vue';
 import Admin from '../pages/Admin.vue';
 import ItemAdmin from '../pages/ItemAdmin.vue';
 import ItemCategoryAdmin from '../pages/ItemCategoryAdmin.vue';
+import MapResourceAdmin from '../pages/MapResourceAdmin.vue';
 
 const routes = [
   { path: '/', name: 'Home', component: Home },
@@ -23,6 +24,7 @@ const routes = [
   { path: '/admin', name: 'Admin', component: Admin },
   { path: '/admin/items', name: 'ItemAdmin', component: ItemAdmin },
   { path: '/admin/itemcategories', name: 'ItemCategoryAdmin', component: ItemCategoryAdmin },
+  { path: '/admin/mapresources', name: 'MapResourceAdmin', component: MapResourceAdmin },
 ];
 
 const router = createRouter({

--- a/mogoDB.md/itemcategories.md
+++ b/mogoDB.md/itemcategories.md
@@ -28,3 +28,13 @@ db.itemcategories.createIndex({ name: 1 });
 ```bash
 mongoimport --db dts --collection itemcategories --file ../data/itemCategories.json --jsonArray
 ```
+
+已有数据若缺少 `tables` 字段，可执行：
+
+```javascript
+use dts;
+db.itemcategories.updateMany(
+  { tables: { $exists: false } },
+  { $set: { tables: [] } }
+);
+```

--- a/mogoDB.md/itemcategories.md
+++ b/mogoDB.md/itemcategories.md
@@ -6,6 +6,8 @@
 {
   name: '默认地图掉落',
   type: 'mapitem', // 或 'maptrap'
+  // tables 表示引用的刷新表名称数组，可在后台多选
+  tables: ['mapitem'],
   // stage 表示刷新的阶段，可选值：'start', 'ban2', 'ban4'
   items: [
     { itemId: 1, pls: 1, count: 2, stage: 'start' },


### PR DESCRIPTION
## Summary
- 地图资源管理新增NPC分组，可按区域查看、添加与编辑NPC
- 树节点增加NPC和区域编辑能力

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68881d71118083228867e1ca20fb6904