### PR TITLE
Fix ItemCategoryAdmin script section

### DIFF
--- a/frontend/src/pages/ItemCategoryAdmin.vue
+++ b/frontend/src/pages/ItemCategoryAdmin.vue
@@ -85,8 +85,9 @@
   </div>
 </template>
 
+<script setup>
 
-import { ref, reactive, onMounted, watchEffect } from 'vue'
+import { ref, reactive, onMounted, watchEffect, computed } from 'vue'
 import { adminList, adminCreate, adminUpdate, adminDelete, getMapAreas } from '../api'
 import { mapAreas } from '../store/map'
 import { itemTypeText, trapTypeText } from '../constants/enums'


### PR DESCRIPTION
## Summary
- fix Vue compile error by adding missing `<script setup>` section
- import `computed` from Vue

## Testing
- `npm run lint` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688825bb84008322b1759766df58760a