### PR TITLE
修复地图资源管理添加功能并精简后台菜单

### DIFF
--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -19,14 +19,11 @@
       :items="items"
       :field-meta="fieldMeta"
       :is-maps="isMaps"
-      :is-map-areas="isMapAreas"
       :loading="loading"
       :map-areas="mapAreas"
       @load-more="loadMore"
       @edit="openFieldEdit"
       @remove="remove"
-      @open="openArea"
-      @close="closeArea"
     />
     <FormDialog
       v-model="fieldDialogVisible"
@@ -59,9 +56,7 @@ import {
   adminDelete,
   adminFieldMeta,
   adminMaps,
-  getMapAreas,
-  adminOpenArea,
-  adminCloseArea
+  getMapAreas
 } from '../api'
 import { mapAreas } from '../store/map'
 import { trapTypeText } from '../constants/enums'
@@ -79,8 +74,7 @@ const collections = [
   { label: '历史记录', value: 'histories' },
   { label: '游戏信息', value: 'gameinfos' },
   { label: '用户', value: 'users' },
-  { label: '地图', value: 'maps' },
-  { label: '地图区域', value: 'mapareas' }
+  { label: '地图', value: 'maps' }
 ]
 
 const collection = ref('')
@@ -99,7 +93,6 @@ const editForm = ref({})
 const createDialogVisible = ref(false)
 const createData = ref({})
 const isMaps = computed(() => collection.value === 'maps')
-const isMapAreas = computed(() => collection.value === 'mapareas')
 const areaFilter = ref(-1)
 
 watch(collection, () => {
@@ -164,15 +157,6 @@ async function fetchItems(append = false) {
       items.value = append ? items.value.concat(list) : list
       if (list.length < limit) allLoaded.value = true
       skip.value += list.length
-    } else if (collection.value === 'mapareas') {
-      const { data } = await adminList('mapareas', { skip: skip.value, limit })
-      items.value = append ? items.value.concat(data) : data
-      if (data.length < limit) allLoaded.value = true
-      skip.value += data.length
-      try {
-        const res = await getMapAreas()
-        mapAreas.value = res.data
-      } catch {}
     } else if (collection.value === 'maptraps') {
       if (!mapAreas.value.length) {
         try {
@@ -286,23 +270,6 @@ async function remove(row) {
   }
 }
 
-async function openArea(row) {
-  try {
-    await adminOpenArea(row.pid)
-    row.danger = 1
-  } catch (e) {
-    alert(e.response?.data?.msg || '操作失败')
-  }
-}
-
-async function closeArea(row) {
-  try {
-    await adminCloseArea(row.pid)
-    row.danger = 0
-  } catch (e) {
-    alert(e.response?.data?.msg || '操作失败')
-  }
-}
 </script>
 
 <style scoped>

--- a/frontend/src/pages/MapResourceAdmin.vue
+++ b/frontend/src/pages/MapResourceAdmin.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="page">
-    <h2>地图资源管理</h2>
+  <h2>地图资源管理</h2>
+  <el-button style="margin-bottom:10px" size="small" @click="router.push('/admin')">返回后台</el-button>
     <el-tree
       :data="treeData"
       :props="treeProps"
@@ -134,14 +135,13 @@ function buildTree(areas, items, traps, cats, shops, npcs) {
       area: a.pid,
       data: it,
     }));
-    if (itemsList.length)
-      children.push({
-        id: `items-${a.pid}`,
-        label: '地图物品',
-        type: 'itemGroup',
-        area: a.pid,
-        children: itemsList,
-      });
+    children.push({
+      id: `items-${a.pid}`,
+      label: '地图物品',
+      type: 'itemGroup',
+      area: a.pid,
+      children: itemsList,
+    });
     const trapsList = (trapByArea[a.pid] || []).map((it) => ({
       id: it._id,
       label: it.itm,
@@ -149,14 +149,13 @@ function buildTree(areas, items, traps, cats, shops, npcs) {
       area: a.pid,
       data: it,
     }));
-    if (trapsList.length)
-      children.push({
-        id: `traps-${a.pid}`,
-        label: '陷阱',
-        type: 'trapGroup',
-        area: a.pid,
-        children: trapsList,
-      });
+    children.push({
+      id: `traps-${a.pid}`,
+      label: '陷阱',
+      type: 'trapGroup',
+      area: a.pid,
+      children: trapsList,
+    });
     const catList = (catByArea[a.pid] || []).map((c) => ({
       id: c._id,
       label: c.name,
@@ -164,14 +163,13 @@ function buildTree(areas, items, traps, cats, shops, npcs) {
       area: a.pid,
       data: c,
     }));
-    if (catList.length)
-      children.push({
-        id: `cats-${a.pid}`,
-        label: '刷新表',
-        type: 'catGroup',
-        area: a.pid,
-        children: catList,
-      });
+    children.push({
+      id: `cats-${a.pid}`,
+      label: '刷新表',
+      type: 'catGroup',
+      area: a.pid,
+      children: catList,
+    });
     const shopList = (shopByArea[a.pid] || []).map((s) => ({
       id: s._id,
       label: s.item,
@@ -202,14 +200,13 @@ function buildTree(areas, items, traps, cats, shops, npcs) {
       area: a.pid,
       data: n,
     }));
-    if (npcList.length)
-      children.push({
-        id: `npcs-${a.pid}`,
-        label: 'NPC',
-        type: 'npcGroup',
-        area: a.pid,
-        children: npcList,
-      });
+    children.push({
+      id: `npcs-${a.pid}`,
+      label: 'NPC',
+      type: 'npcGroup',
+      area: a.pid,
+      children: npcList,
+    });
     return {
       id: a._id,
       label: a.name,
@@ -262,8 +259,10 @@ async function openCreate(group) {
   dialogFields.value = fields;
   dialogTitle.value = '新建';
   formData.value = {};
-  if (col === 'mapitems' || col === 'maptraps' || col === 'npcs')
+  if (col === 'mapitems' || col === 'maptraps' || col === 'npcs') {
     formData.value.pls = group.area;
+    if (col === 'mapitems') formData.value.stage = 'start';
+  }
   if (col === 'shopitems') formData.value.area = group.area;
   dialogVisible.value = true;
 }


### PR DESCRIPTION
## Summary
- 在地图资源管理页加入返回后台按钮
- 允许无物品时也能添加地图物品、陷阱、刷新表及NPC
- 新建地图物品默认刷新阶段为`start`
- 移除后台“地图区域”分类，相关开关区域功能一并删除

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888276f21b88322a3f9b19658c063b0