### PR TITLE
Add NPC spawn admin and map card layout

### DIFF
--- a/backend/src/fieldsMeta.js
+++ b/backend/src/fieldsMeta.js
@@ -159,6 +159,18 @@ module.exports = {
       options: ['mapitem', 'mapitem_i8', 'mapitem_i9'],
     },
   ],
+  npcspawns: [
+    { name: 'area', label: '区域ID', type: 'number' },
+    { name: 'type', label: 'NPC类型', type: 'number' },
+    { name: 'sub', label: '子类别', type: 'number' },
+    { name: 'num', label: '数量', type: 'number' },
+    {
+      name: 'stage',
+      label: '刷新阶段',
+      type: 'select',
+      options: ['start', 'ban2', 'ban4'],
+    },
+  ],
   maps: [
     { name: 'pls', label: '区域ID', type: 'number' },
     { name: 'name', label: '区域名', type: 'text' },

--- a/backend/src/models/NpcSpawn.js
+++ b/backend/src/models/NpcSpawn.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const npcSpawnSchema = new mongoose.Schema({
+  area: { type: Number, index: true },
+  type: { type: Number, default: 1 },
+  sub: { type: Number, default: 0 },
+  num: { type: Number, default: 1 },
+  stage: { type: String, default: 'start', index: true },
+});
+
+module.exports = mongoose.model('NpcSpawn', npcSpawnSchema);

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -21,6 +21,7 @@ const models = {
   histories: require('../models/History'),
   gameinfos: require('../models/GameInfo'),
   users: require('../models/User'),
+  npcspawns: require('../models/NpcSpawn'),
 };
 
 router.use(auth);

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -69,6 +69,7 @@ const collections = [
   { label: '日志', value: 'logs' },
   { label: '聊天', value: 'chats' },
   { label: '地图资源', value: 'mapresources' },
+  { label: 'NPC刷新机制', value: 'npcspawns' },
   { label: '新闻', value: 'newsinfos' },
   { label: '房间监听', value: 'roomlisteners' },
   { label: '历史记录', value: 'histories' },
@@ -98,6 +99,10 @@ const areaFilter = ref(-1)
 watch(collection, () => {
   if (collection.value === 'mapresources') {
     router.push('/admin/mapresources')
+    return
+  }
+  if (collection.value === 'npcspawns') {
+    router.push('/admin/npcspawns')
     return
   }
   skip.value = 0

--- a/frontend/src/pages/MapResourceAdmin.vue
+++ b/frontend/src/pages/MapResourceAdmin.vue
@@ -1,48 +1,70 @@
 <template>
   <div class="page">
-  <h2>地图资源管理</h2>
-  <el-button style="margin-bottom:10px" size="small" @click="router.push('/admin')">返回后台</el-button>
-    <el-tree
-      :data="treeData"
-      :props="treeProps"
-      node-key="id"
-      default-expand-all
-      @node-click="handleNodeClick"
-    >
-      <template #default="{ node, data }">
-        <span>{{ node.label }}</span>
-        <span v-if="data.type === 'shopitem'"> x{{ data.num }}</span>
-        <el-button
-          v-if="['itemGroup','trapGroup','shopGroup','npcGroup'].includes(data.type)"
-          text
-          size="small"
-          @click.stop="openCreate(data)"
-          >添加</el-button
-        >
-        <el-button
-          v-if="['mapitem','maptrap','shopitem','npc','area'].includes(data.type)"
-          text
-          size="small"
-          @click.stop="openEdit(data)"
-          >编辑</el-button
-        >
-        <el-button
-          v-if="['mapitem','maptrap','shopitem','npc'].includes(data.type)"
-          text
-          size="small"
-          type="danger"
-          @click.stop="removeNode(data)"
-          >删除</el-button
-        >
-        <el-button
-          v-if="data.type === 'category'"
-          text
-          size="small"
-          @click.stop="goCategory"
-          >编辑刷新表</el-button
-        >
-      </template>
-    </el-tree>
+    <h2>地图资源管理</h2>
+    <template v-if="!areaId">
+      <el-button type="primary" size="small" style="margin-bottom:10px" @click="openCreateArea">新建地图</el-button>
+      <el-row :gutter="20" style="margin-top:10px">
+        <el-col v-for="a in areas" :key="a.pid" :span="8">
+          <el-card shadow="hover">
+            <template #header>
+              <span>{{ a.name }}</span>
+              <div style="float:right">
+                <el-button text size="small" @click="editArea(a)">编辑</el-button>
+                <el-button text size="small" type="danger" @click="removeArea(a)">删除</el-button>
+              </div>
+            </template>
+            <div style="text-align:center">
+              <el-button size="small" @click="goArea(a.pid)">资源详情</el-button>
+              <el-button size="small" @click="goNpcSpawn(a.pid)">NPC刷新机制</el-button>
+            </div>
+          </el-card>
+        </el-col>
+      </el-row>
+    </template>
+    <template v-else>
+      <el-button style="margin-bottom:10px" size="small" @click="router.push('/admin/mapresources')">返回</el-button>
+      <el-tree
+        :data="treeData"
+        :props="treeProps"
+        node-key="id"
+        default-expand-all
+        @node-click="handleNodeClick"
+      >
+        <template #default="{ node, data }">
+          <span>{{ node.label }}</span>
+          <span v-if="data.type === 'shopitem'"> x{{ data.num }}</span>
+          <el-button
+            v-if="['itemGroup','trapGroup','shopGroup','npcGroup'].includes(data.type)"
+            text
+            size="small"
+            @click.stop="openCreate(data)"
+            >添加</el-button
+          >
+          <el-button
+            v-if="['mapitem','maptrap','shopitem','npc','area'].includes(data.type)"
+            text
+            size="small"
+            @click.stop="openEdit(data)"
+            >编辑</el-button
+          >
+          <el-button
+            v-if="['mapitem','maptrap','shopitem','npc'].includes(data.type)"
+            text
+            size="small"
+            type="danger"
+            @click.stop="removeNode(data)"
+            >删除</el-button
+          >
+          <el-button
+            v-if="data.type === 'category'"
+            text
+            size="small"
+            @click.stop="goCategory"
+            >编辑刷新表</el-button
+          >
+        </template>
+      </el-tree>
+    </template>
     <FormDialog
       v-model="dialogVisible"
       :title="dialogTitle"
@@ -56,7 +78,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRouter, useRoute } from 'vue-router';
 import {
   adminList,
   adminCreate,
@@ -67,6 +89,9 @@ import {
 import FormDialog from '../components/FormDialog.vue';
 
 const router = useRouter();
+const route = useRoute();
+const areaId = route.query.area ? Number(route.query.area) : 0;
+const areas = ref([]);
 const treeData = ref([]);
 const treeProps = { children: 'children', label: 'label' };
 
@@ -79,8 +104,16 @@ let editId = '';
 let currentArea = 0;
 
 onMounted(() => {
-  fetchData();
+  if (areaId) fetchData();
+  else fetchAreas();
 });
+
+async function fetchAreas() {
+  try {
+    const { data } = await adminList('mapareas', { limit: 1000 })
+    areas.value = data
+  } catch {}
+}
 
 async function fetchData() {
   try {
@@ -91,7 +124,7 @@ async function fetchData() {
       adminList('itemcategories', { limit: 1000 }),
       adminList('shopitems', { limit: 1000 }),
       adminList('npcs', { limit: 1000 }),
-    ]);
+    ])
     buildTree(
       areasRes.data,
       itemsRes.data,
@@ -99,7 +132,10 @@ async function fetchData() {
       catsRes.data,
       shopsRes.data,
       npcsRes.data,
-    );
+    )
+    if (areaId) {
+      treeData.value = treeData.value.filter(t => t.area === areaId)
+    }
   } catch {}
 }
 
@@ -296,6 +332,44 @@ async function removeNode(data) {
     fetchData();
   } catch (e) {
     alert(e.response?.data?.msg || '删除失败');
+  }
+}
+
+function goArea(pid) {
+  router.push(`/admin/mapresources?area=${pid}`)
+}
+
+function goNpcSpawn(pid) {
+  router.push(`/admin/npcspawns?area=${pid}`)
+}
+
+async function openCreateArea() {
+  editCollection = 'mapareas'
+  editId = ''
+  const { data: fields } = await adminFieldMeta('mapareas')
+  dialogFields.value = fields
+  dialogTitle.value = '新建地图'
+  formData.value = {}
+  dialogVisible.value = true
+}
+
+async function editArea(area) {
+  editCollection = 'mapareas'
+  editId = area._id
+  const { data: fields } = await adminFieldMeta('mapareas')
+  dialogFields.value = fields
+  dialogTitle.value = '编辑地图'
+  formData.value = { ...area }
+  dialogVisible.value = true
+}
+
+async function removeArea(area) {
+  if (!confirm('确定删除？')) return
+  try {
+    await adminDelete('mapareas', area._id)
+    fetchAreas()
+  } catch (e) {
+    alert(e.response?.data?.msg || '删除失败')
   }
 }
 

--- a/frontend/src/pages/NpcSpawnAdmin.vue
+++ b/frontend/src/pages/NpcSpawnAdmin.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="page">
+    <h2>NPC刷新机制管理</h2>
+    <el-button type="primary" size="small" @click="openCreate" style="margin-bottom:10px">新建</el-button>
+    <TablePanel
+      :items="items"
+      :field-meta="fields"
+      :loading="loading"
+      @load-more="loadMore"
+      @edit="openEdit"
+      @remove="removeRow"
+    />
+    <FormDialog
+      v-model="dialogVisible"
+      :title="dialogTitle"
+      :fields="fields"
+      :form="formData"
+      @save="saveDialog"
+      @close="dialogVisible = false"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import TablePanel from '../components/TablePanel.vue'
+import FormDialog from '../components/FormDialog.vue'
+import { adminList, adminCreate, adminUpdate, adminDelete, adminFieldMeta } from '../api'
+
+const items = ref([])
+const fields = ref([])
+const loading = ref(false)
+const skip = ref(0)
+const limit = 50
+const dialogVisible = ref(false)
+const dialogTitle = ref('')
+const formData = ref({})
+let editId = ''
+
+onMounted(async () => {
+  const { data } = await adminFieldMeta('npcspawns')
+  fields.value = data
+  fetchItems()
+})
+
+async function fetchItems(append=false){
+  loading.value = true
+  try{
+    const { data } = await adminList('npcspawns', { skip: skip.value, limit })
+    items.value = append ? items.value.concat(data) : data
+    skip.value += data.length
+  }catch(e){
+    alert(e.response?.data?.msg || '加载失败')
+  }finally{
+    loading.value = false
+  }
+}
+
+function loadMore(){ fetchItems(true) }
+
+function openEdit(row){
+  editId = row._id
+  dialogTitle.value = '编辑'
+  formData.value = { ...row }
+  dialogVisible.value = true
+}
+
+function openCreate(){
+  editId = ''
+  dialogTitle.value = '新建'
+  formData.value = {}
+  dialogVisible.value = true
+}
+
+async function saveDialog(){
+  try{
+    if(editId){
+      await adminUpdate('npcspawns', editId, formData.value)
+    }else{
+      await adminCreate('npcspawns', formData.value)
+    }
+    dialogVisible.value = false
+    skip.value = 0
+    fetchItems()
+  }catch(e){
+    alert(e.response?.data?.msg || '保存失败')
+  }
+}
+
+async function removeRow(row){
+  if(!confirm('确定删除？')) return
+  try{
+    await adminDelete('npcspawns', row._id)
+    skip.value = 0
+    fetchItems()
+  }catch(e){
+    alert(e.response?.data?.msg || '删除失败')
+  }
+}
+</script>
+
+<style scoped>
+.page {
+  padding: 20px;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -11,6 +11,7 @@ import Admin from '../pages/Admin.vue';
 import ItemAdmin from '../pages/ItemAdmin.vue';
 import ItemCategoryAdmin from '../pages/ItemCategoryAdmin.vue';
 import MapResourceAdmin from '../pages/MapResourceAdmin.vue';
+import NpcSpawnAdmin from '../pages/NpcSpawnAdmin.vue';
 
 const routes = [
   { path: '/', name: 'Home', component: Home },
@@ -25,6 +26,7 @@ const routes = [
   { path: '/admin/items', name: 'ItemAdmin', component: ItemAdmin },
   { path: '/admin/itemcategories', name: 'ItemCategoryAdmin', component: ItemCategoryAdmin },
   { path: '/admin/mapresources', name: 'MapResourceAdmin', component: MapResourceAdmin },
+  { path: '/admin/npcspawns', name: 'NpcSpawnAdmin', component: NpcSpawnAdmin },
 ];
 
 const router = createRouter({

--- a/mogoDB.md/npcspawns.md
+++ b/mogoDB.md/npcspawns.md
@@ -1,0 +1,27 @@
+# npcspawns 集合说明
+
+用于定义各个地图区域在不同阶段刷新的 NPC 组。字段如下：
+
+```javascript
+{
+  area: 1,      // 地图区域ID
+  type: 4,      // NPC 类型
+  sub: 0,       // 子类别
+  num: 1,       // 刷新数量
+  stage: 'start' // 刷新阶段，可选 'start' | 'ban2' | 'ban4'
+}
+```
+
+在 MongoDB shell 中初始化集合并建立索引：
+
+```javascript
+use dts;
+db.npcspawns.createIndex({ area: 1 });
+db.npcspawns.createIndex({ stage: 1 });
+```
+
+可批量导入 `data/npcspawns.json`（需自行准备）：
+
+```bash
+mongoimport --db dts --collection npcspawns --file ../data/npcspawns.json --jsonArray
+```


### PR DESCRIPTION
## Summary
- add `NpcSpawn` model and admin endpoints
- document `npcspawns` collection setup
- support NPC spawn admin page
- show map resources in card layout with area CRUD
- add NPC spawn admin route and menu option

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888299becf88322a3b37b9b82267850