### PR TITLE
Add NPC spawn integration and update map resource UI

### DIFF
--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -6,6 +6,7 @@ const MapItem = require('../models/MapItem');
 const MapTrap = require('../models/MapTrap');
 const Item = require('../models/Item');
 const ItemCategory = require('../models/ItemCategory');
+const NpcSpawn = require('../models/NpcSpawn');
 const Club = require('../models/Club');
 const Chat = require('../models/Chat');
 const constants = require('../config/constants');
@@ -168,24 +169,9 @@ async function startGame() {
   } catch (e) {
     console.error('清理旧玩家数据失败', e);
   }
-
   try {
-    const npcFile = path.join(__dirname, '../../../data/npcs.json');
-    const npcs = JSON.parse(fs.readFileSync(npcFile));
     await Player.deleteMany({ type: { $gt: 0 } });
-    if (npcs && npcs.length) {
-      const startNpcs = npcs
-        .filter((n) => !n.spawnStage || n.spawnStage === 'start')
-        .map((n) => ({
-          ...n,
-          hp: n.hp || n.mhp || 0,
-          sp: n.sp || n.msp || 0,
-          ss: n.ss || n.mss || 0,
-        }));
-      if (startNpcs.length) {
-        await Player.insertMany(startNpcs);
-      }
-    }
+    await spawnNpcs('start');
   } catch (e) {
     console.error('初始化 NPC 失败', e);
   }
@@ -219,14 +205,39 @@ async function spawnNpcs(stage) {
   try {
     const npcFile = path.join(__dirname, '../../../data/npcs.json');
     const npcs = JSON.parse(fs.readFileSync(npcFile));
-    const list = npcs
-      .filter((n) => n.spawnStage === stage)
-      .map((n) => ({
-        ...n,
-        hp: n.hp || n.mhp || 0,
-        sp: n.sp || n.msp || 0,
-        ss: n.ss || n.mss || 0,
-      }));
+    const spawns = await NpcSpawn.find({ stage });
+    let list = [];
+    if (spawns.length) {
+      for (const s of spawns) {
+        const pool = npcs.filter(
+          (n) =>
+            n.type === s.type &&
+            (s.sub ? n.sub === s.sub : true) &&
+            (!n.spawnStage || n.spawnStage === stage),
+        );
+        for (let i = 0; i < s.num; i++) {
+          const base = pool[i % pool.length];
+          if (base) {
+            list.push({
+              ...base,
+              pls: s.area,
+              hp: base.hp || base.mhp || 0,
+              sp: base.sp || base.msp || 0,
+              ss: base.ss || base.mss || 0,
+            });
+          }
+        }
+      }
+    } else {
+      list = npcs
+        .filter((n) => n.spawnStage === stage)
+        .map((n) => ({
+          ...n,
+          hp: n.hp || n.mhp || 0,
+          sp: n.sp || n.msp || 0,
+          ss: n.ss || n.mss || 0,
+        }));
+    }
     if (list.length) {
       await Player.insertMany(list);
     }

--- a/data/initData.js
+++ b/data/initData.js
@@ -45,6 +45,13 @@ if (mapitems.length) {
   db.mapitems.insertMany(mapitems);
 }
 
+// 导入 npcspawns
+var npcspawns = JSON.parse(cat('./npcspawns.json')); // may be empty
+if (npcspawns.length) {
+  db.npcspawns.remove({});
+  db.npcspawns.insertMany(npcspawns);
+}
+
 // 导入 itemcategories
 var itemcategories = JSON.parse(cat('./itemCategories.json'));
 if (itemcategories.length) {

--- a/data/npcspawns.json
+++ b/data/npcspawns.json
@@ -1,0 +1,3 @@
+[
+  {"area": 0, "type": 1, "sub": 0, "num": 1, "stage": "start"}
+]

--- a/frontend/src/pages/MapResourceAdmin.vue
+++ b/frontend/src/pages/MapResourceAdmin.vue
@@ -28,12 +28,22 @@
               </div>
             </template>
             <div style="text-align: center">
-              <el-button size="small" @click="goArea(a.pid)"
-                >资源详情</el-button
-              >
-              <el-button size="small" @click="goNpcSpawn(a.pid)"
-                >NPC刷新机制</el-button
-              >
+              <el-button size="small" @click="goArea(a.pid)">地图物品</el-button>
+              <el-button size="small" @click="goCategory">地图物品刷新</el-button>
+              <el-button size="small" @click="goArea(a.pid)">地图陷阱</el-button>
+              <el-button size="small" @click="goCategory">地图陷阱刷新</el-button>
+              <el-switch
+                v-model="shopMap[a.pid]"
+                size="small"
+                @change="toggleShop(a.pid)"
+                style="margin: 0 5px"
+              />
+              <el-button
+                v-if="shopMap[a.pid]"
+                size="small"
+                @click="goArea(a.pid)"
+                >商店物品</el-button>
+              <el-button size="small" @click="goNpcSpawn(a.pid)">NPC刷新机制</el-button>
             </div>
           </el-card>
         </el-col>
@@ -123,6 +133,7 @@ const router = useRouter();
 const route = useRoute();
 const areaId = ref(route.query.area ? Number(route.query.area) : 0);
 const areas = ref([]);
+const shopMap = ref({});
 const treeData = ref([]);
 const treeProps = { children: 'children', label: 'label' };
 
@@ -153,8 +164,16 @@ watch(
 
 async function fetchAreas() {
   try {
-    const { data } = await adminList('mapareas', { limit: 1000 });
-    areas.value = data;
+    const [areasRes, shopsRes] = await Promise.all([
+      adminList('mapareas', { limit: 1000 }),
+      adminList('shopitems', { limit: 1000 }),
+    ]);
+    areas.value = areasRes.data;
+    const map = {};
+    (shopsRes.data || []).forEach((s) => {
+      map[s.area] = true;
+    });
+    shopMap.value = map;
   } catch {}
 }
 
@@ -416,6 +435,10 @@ async function removeArea(area) {
   } catch (e) {
     alert(e.response?.data?.msg || '删除失败');
   }
+}
+
+function toggleShop(pid) {
+  shopMap.value[pid] = !shopMap.value[pid];
 }
 
 function goCategory() {

--- a/mogoDB.md/npcspawns.md
+++ b/mogoDB.md/npcspawns.md
@@ -25,3 +25,5 @@ db.npcspawns.createIndex({ stage: 1 });
 ```bash
 mongoimport --db dts --collection npcspawns --file ../data/npcspawns.json --jsonArray
 ```
+
+如果希望让开局 NPC 也由刷新机制管理，可从 `data/npcs.json` 中整理 `spawnStage` 为 `start` 的 NPC，按区域(`pls`)、类型(`type`)和子类别(`sub`)汇总数量，生成 `data/npcspawns.json` 后导入。


### PR DESCRIPTION
## Summary
- manage initial NPCs via the NPC spawn mechanism
- store NPC spawn data in `npcspawns` collection
- import NPC spawns during initial data setup
- enhance map resource admin cards with item/trap buttons and shop switch
- document importing start NPCs into npcspawns

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688830c1fc448322a720c760df30656f