### PR TITLE
Improve map resource UI and fix shop toggle

### DIFF
--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -2,19 +2,42 @@
   <div class="page">
     <h2>后台管理</h2>
     <el-select v-model="collection" placeholder="选择集合" style="width: 200px">
-      <el-option v-for="c in collections" :key="c.value" :label="c.label" :value="c.value" />
+      <el-option
+        v-for="c in collections"
+        :key="c.value"
+        :label="c.label"
+        :value="c.value"
+      />
     </el-select>
     <el-select
       v-if="collection === 'mapitems'"
       v-model="areaFilter"
       placeholder="区域过滤"
-      style="width: 160px; margin-left:10px"
+      style="width: 160px; margin-left: 10px"
     >
       <el-option :label="'全部'" :value="-1" />
-      <el-option v-for="area in mapAreas" :key="area.pid" :label="area.name" :value="area.pid" />
+      <el-option
+        v-for="area in mapAreas"
+        :key="area.pid"
+        :label="area.name"
+        :value="area.pid"
+      />
     </el-select>
-    <el-button v-if="!isMaps" type="primary" size="small" @click="openCreate" style="margin-left:10px">新建</el-button>
-    <el-button v-if="collection === 'itemcategories'" size="small" style="margin-left:10px" @click="$router.push('/admin/itemcategories')">高级编辑</el-button>
+    <el-button
+      v-if="!isMaps"
+      type="primary"
+      size="small"
+      @click="openCreate"
+      style="margin-left: 10px"
+      >新建</el-button
+    >
+    <el-button
+      v-if="collection === 'itemcategories'"
+      size="small"
+      style="margin-left: 10px"
+      @click="$router.push('/admin/itemcategories')"
+      >高级编辑</el-button
+    >
     <TablePanel
       :items="items"
       :field-meta="fieldMeta"
@@ -27,10 +50,10 @@
     />
     <FormDialog
       v-model="fieldDialogVisible"
-      :title="'编辑 '+(editField?.label||'')"
+      :title="'编辑 ' + (editField?.label || '')"
       :fields="editField ? [editField] : []"
       :form="editForm"
-      @close="fieldDialogVisible=false"
+      @close="fieldDialogVisible = false"
       @save="saveField"
     />
     <FormDialog
@@ -38,17 +61,17 @@
       title="新建"
       :fields="fieldMeta"
       :form="createData"
-      @close="createDialogVisible=false"
+      @close="createDialogVisible = false"
       @save="saveCreate"
     />
   </div>
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue'
-import { useRouter } from 'vue-router'
-import TablePanel from '../components/TablePanel.vue'
-import FormDialog from '../components/FormDialog.vue'
+import { ref, watch, computed } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import TablePanel from '../components/TablePanel.vue';
+import FormDialog from '../components/FormDialog.vue';
 import {
   adminList,
   adminCreate,
@@ -56,12 +79,13 @@ import {
   adminDelete,
   adminFieldMeta,
   adminMaps,
-  getMapAreas
-} from '../api'
-import { mapAreas } from '../store/map'
-import { trapTypeText } from '../constants/enums'
+  getMapAreas,
+} from '../api';
+import { mapAreas } from '../store/map';
+import { trapTypeText } from '../constants/enums';
 
-const router = useRouter()
+const router = useRouter();
+const route = useRoute();
 const collections = [
   { label: '玩家', value: 'players' },
   { label: 'NPC', value: 'npcs' },
@@ -75,206 +99,239 @@ const collections = [
   { label: '历史记录', value: 'histories' },
   { label: '游戏信息', value: 'gameinfos' },
   { label: '用户', value: 'users' },
-  { label: '地图', value: 'maps' }
-]
+  { label: '地图', value: 'maps' },
+];
 
-const collection = ref('')
-const fieldMeta = ref([])
-const items = ref([])
-const skip = ref(0)
-const limit = 50
-const loading = ref(false)
-const allLoaded = ref(false)
+const collection = ref('');
+const fieldMeta = ref([]);
+const items = ref([]);
+const skip = ref(0);
+const limit = 50;
+const loading = ref(false);
+const allLoaded = ref(false);
 
-const fieldDialogVisible = ref(false)
-const editField = ref(null)
-const editRowId = ref('')
-const editForm = ref({})
+const fieldDialogVisible = ref(false);
+const editField = ref(null);
+const editRowId = ref('');
+const editForm = ref({});
 
-const createDialogVisible = ref(false)
-const createData = ref({})
-const isMaps = computed(() => collection.value === 'maps')
-const areaFilter = ref(-1)
+const createDialogVisible = ref(false);
+const createData = ref({});
+const isMaps = computed(() => collection.value === 'maps');
+const areaFilter = ref(-1);
 
-watch(collection, () => {
-  if (collection.value === 'mapresources') {
-    router.push('/admin/mapresources')
-    return
-  }
-  if (collection.value === 'npcspawns') {
-    router.push('/admin/npcspawns')
-    return
-  }
-  skip.value = 0
-  allLoaded.value = false
-  items.value = []
-  fetchFieldMeta()
-  fetchItems()
-}, { immediate: true })
+watch(
+  () => route.query.collection,
+  (v) => {
+    if (v && collections.some((c) => c.value === v)) {
+      collection.value = v;
+    }
+  },
+  { immediate: true },
+);
+
+watch(
+  collection,
+  () => {
+    if (collection.value === 'mapresources') {
+      router.push('/admin/mapresources');
+      return;
+    }
+    if (collection.value === 'npcspawns') {
+      router.push('/admin/npcspawns');
+      return;
+    }
+    router.replace({ path: '/admin', query: { collection: collection.value } });
+    skip.value = 0;
+    allLoaded.value = false;
+    items.value = [];
+    fetchFieldMeta();
+    fetchItems();
+  },
+  { immediate: true },
+);
 watch(areaFilter, () => {
   if (collection.value === 'mapitems') {
-    skip.value = 0
-    allLoaded.value = false
-    items.value = []
-    fetchItems()
+    skip.value = 0;
+    allLoaded.value = false;
+    items.value = [];
+    fetchItems();
   }
-})
+});
 
 async function fetchFieldMeta() {
-  if (!collection.value) return
+  if (!collection.value) return;
   try {
-    if ((collection.value === 'maptraps' || collection.value === 'mapitems' || collection.value === 'players') && !mapAreas.value.length) {
+    if (
+      (collection.value === 'maptraps' ||
+        collection.value === 'mapitems' ||
+        collection.value === 'players') &&
+      !mapAreas.value.length
+    ) {
       try {
-        const res = await getMapAreas()
-        mapAreas.value = res.data
+        const res = await getMapAreas();
+        mapAreas.value = res.data;
       } catch {}
     }
-    const { data } = await adminFieldMeta(collection.value)
-    fieldMeta.value = data.map(f => {
-      const nf = { ...f }
+    const { data } = await adminFieldMeta(collection.value);
+    fieldMeta.value = data.map((f) => {
+      const nf = { ...f };
       if ((nf.name === 'pls' || nf.name === 'area') && mapAreas.value.length) {
-        nf.type = 'select'
-        nf.options = mapAreas.value.map(a => ({ label: a.name, value: a.pid }))
+        nf.type = 'select';
+        nf.options = mapAreas.value.map((a) => ({
+          label: a.name,
+          value: a.pid,
+        }));
       }
       if (collection.value === 'maptraps' && nf.name === 'itmk') {
-        nf.type = 'select'
-        nf.options = Object.entries(trapTypeText).map(([k, v]) => ({ label: v, value: k }))
+        nf.type = 'select';
+        nf.options = Object.entries(trapTypeText).map(([k, v]) => ({
+          label: v,
+          value: k,
+        }));
       }
-      return nf
-    })
+      return nf;
+    });
   } catch (e) {
-    fieldMeta.value = []
+    fieldMeta.value = [];
   }
 }
 
 async function fetchItems(append = false) {
-  if (!collection.value || loading.value || allLoaded.value) return
-  loading.value = true
+  if (!collection.value || loading.value || allLoaded.value) return;
+  loading.value = true;
   try {
     if (collection.value === 'maps') {
-      const { data } = await adminMaps()
-      const list = data.map(d => ({
+      const { data } = await adminMaps();
+      const list = data.map((d) => ({
         _id: d.pls,
         pls: d.pls,
         name: d.name,
-        players: d.players.map(p => `${p.name}(${p.pid})`).join(', ')
-      }))
-      items.value = append ? items.value.concat(list) : list
-      if (list.length < limit) allLoaded.value = true
-      skip.value += list.length
+        players: d.players.map((p) => `${p.name}(${p.pid})`).join(', '),
+      }));
+      items.value = append ? items.value.concat(list) : list;
+      if (list.length < limit) allLoaded.value = true;
+      skip.value += list.length;
     } else if (collection.value === 'maptraps') {
       if (!mapAreas.value.length) {
         try {
-          const res = await getMapAreas()
-          mapAreas.value = res.data
+          const res = await getMapAreas();
+          mapAreas.value = res.data;
         } catch {}
       }
-      const { data } = await adminList('maptraps', { skip: skip.value, limit })
-      items.value = append ? items.value.concat(data) : data
-      if (data.length < limit) allLoaded.value = true
-      skip.value += data.length
+      const { data } = await adminList('maptraps', { skip: skip.value, limit });
+      items.value = append ? items.value.concat(data) : data;
+      if (data.length < limit) allLoaded.value = true;
+      skip.value += data.length;
     } else if (collection.value === 'mapitems') {
       if (!mapAreas.value.length) {
         try {
-          const res = await getMapAreas()
-          mapAreas.value = res.data
+          const res = await getMapAreas();
+          mapAreas.value = res.data;
         } catch {}
       }
-      const params = { skip: skip.value, limit }
-      if (areaFilter.value !== -1) params.pls = areaFilter.value
-      const { data } = await adminList('mapitems', params)
-      items.value = append ? items.value.concat(data) : data
-      if (data.length < limit) allLoaded.value = true
-      skip.value += data.length
+      const params = { skip: skip.value, limit };
+      if (areaFilter.value !== -1) params.pls = areaFilter.value;
+      const { data } = await adminList('mapitems', params);
+      items.value = append ? items.value.concat(data) : data;
+      if (data.length < limit) allLoaded.value = true;
+      skip.value += data.length;
     } else {
-      const { data } = await adminList(collection.value, { skip: skip.value, limit })
+      const { data } = await adminList(collection.value, {
+        skip: skip.value,
+        limit,
+      });
       if (collection.value === 'players') {
         if (!mapAreas.value.length) {
           try {
-            const res = await getMapAreas()
-            mapAreas.value = res.data
+            const res = await getMapAreas();
+            mapAreas.value = res.data;
           } catch {}
         }
       }
-      items.value = append ? items.value.concat(data) : data
-      if (data.length < limit) allLoaded.value = true
-      skip.value += data.length
+      items.value = append ? items.value.concat(data) : data;
+      if (data.length < limit) allLoaded.value = true;
+      skip.value += data.length;
     }
   } catch (e) {
-    alert(e.response?.data?.msg || '加载失败')
+    alert(e.response?.data?.msg || '加载失败');
   } finally {
-    loading.value = false
+    loading.value = false;
   }
 }
 
 function loadMore() {
-  fetchItems(true)
+  fetchItems(true);
 }
 
 function openFieldEdit(row, field) {
-  editRowId.value = row._id
-  const f = { ...field }
+  editRowId.value = row._id;
+  const f = { ...field };
   if ((f.name === 'pls' || f.name === 'area') && mapAreas.value.length) {
-    f.type = 'select'
-    f.options = mapAreas.value.map(a => ({ label: a.name, value: a.pid }))
+    f.type = 'select';
+    f.options = mapAreas.value.map((a) => ({ label: a.name, value: a.pid }));
   }
   if (collection.value === 'maptraps' && f.name === 'itmk') {
-    f.type = 'select'
-    f.options = Object.entries(trapTypeText).map(([k, v]) => ({ label: v, value: k }))
+    f.type = 'select';
+    f.options = Object.entries(trapTypeText).map(([k, v]) => ({
+      label: v,
+      value: k,
+    }));
   }
-  editField.value = f
-  editForm.value = { [field.name]: row[field.name] }
-  fieldDialogVisible.value = true
+  editField.value = f;
+  editForm.value = { [field.name]: row[field.name] };
+  fieldDialogVisible.value = true;
 }
 
 async function saveField() {
-  const update = { [editField.value.name]: editForm.value[editField.value.name] }
+  const update = {
+    [editField.value.name]: editForm.value[editField.value.name],
+  };
   try {
-    await adminUpdate(collection.value, editRowId.value, update)
-    fieldDialogVisible.value = false
-    skip.value = 0
-    allLoaded.value = false
-    items.value = []
-    fetchItems()
+    await adminUpdate(collection.value, editRowId.value, update);
+    fieldDialogVisible.value = false;
+    skip.value = 0;
+    allLoaded.value = false;
+    items.value = [];
+    fetchItems();
   } catch (e) {
-    alert(e.response?.data?.msg || '保存失败')
+    alert(e.response?.data?.msg || '保存失败');
   }
 }
 
 function openCreate() {
-  createData.value = {}
-  fieldMeta.value.forEach(f => {
-    createData.value[f.name] = f.type === 'number' ? 0 : ''
-  })
-  createDialogVisible.value = true
+  createData.value = {};
+  fieldMeta.value.forEach((f) => {
+    createData.value[f.name] = f.type === 'number' ? 0 : '';
+  });
+  createDialogVisible.value = true;
 }
 
 async function saveCreate() {
   try {
-    await adminCreate(collection.value, createData.value)
-    createDialogVisible.value = false
-    skip.value = 0
-    allLoaded.value = false
-    items.value = []
-    fetchItems()
+    await adminCreate(collection.value, createData.value);
+    createDialogVisible.value = false;
+    skip.value = 0;
+    allLoaded.value = false;
+    items.value = [];
+    fetchItems();
   } catch (e) {
-    alert(e.response?.data?.msg || '保存失败')
+    alert(e.response?.data?.msg || '保存失败');
   }
 }
 
 async function remove(row) {
-  if (!confirm('确定删除？')) return
+  if (!confirm('确定删除？')) return;
   try {
-    await adminDelete(collection.value, row._id)
-    skip.value = 0
-    allLoaded.value = false
-    items.value = []
-    fetchItems()
+    await adminDelete(collection.value, row._id);
+    skip.value = 0;
+    allLoaded.value = false;
+    items.value = [];
+    fetchItems();
   } catch (e) {
-    alert(e.response?.data?.msg || '删除失败')
+    alert(e.response?.data?.msg || '删除失败');
   }
 }
-
 </script>
 
 <style scoped>
@@ -287,4 +344,3 @@ pre {
   white-space: pre-wrap;
 }
 </style>
-

--- a/frontend/src/pages/MapResourceAdmin.vue
+++ b/frontend/src/pages/MapResourceAdmin.vue
@@ -13,7 +13,9 @@
         <el-col v-for="a in areas" :key="a.pid" :span="8">
           <el-card shadow="hover">
             <template #header>
-              <span>{{ a.name }}</span>
+              <span
+                >{{ a.name }} (ID: {{ a.pid }}, 危险度: {{ a.danger }})</span
+              >
               <div style="float: right">
                 <el-button text size="small" @click="editArea(a)"
                   >编辑</el-button
@@ -27,23 +29,38 @@
                 >
               </div>
             </template>
-            <div style="text-align: center">
-              <el-button size="small" @click="goArea(a.pid)">地图物品</el-button>
-              <el-button size="small" @click="goCategory">地图物品刷新</el-button>
-              <el-button size="small" @click="goArea(a.pid)">地图陷阱</el-button>
-              <el-button size="small" @click="goCategory">地图陷阱刷新</el-button>
+            <div class="btn-row">
+              <el-button size="small" @click="goArea(a.pid)"
+                >地图物品</el-button
+              >
+              <el-button size="small" @click="goCategory">物品刷新表</el-button>
+            </div>
+            <div class="btn-row">
+              <el-button size="small" @click="goArea(a.pid)"
+                >地图陷阱</el-button
+              >
+              <el-button size="small" @click="goCategory">陷阱刷新表</el-button>
+            </div>
+            <div class="btn-row">
+              <span>商店</span>
               <el-switch
                 v-model="shopMap[a.pid]"
                 size="small"
-                @change="toggleShop(a.pid)"
+                @change="(val) => toggleShop(a.pid, val)"
                 style="margin: 0 5px"
               />
               <el-button
                 v-if="shopMap[a.pid]"
                 size="small"
                 @click="goArea(a.pid)"
-                >商店物品</el-button>
-              <el-button size="small" @click="goNpcSpawn(a.pid)">NPC刷新机制</el-button>
+                >商店物品</el-button
+              >
+            </div>
+            <div class="btn-row">
+              <el-button size="small" @click="goNpcAdmin">NPC管理</el-button>
+              <el-button size="small" @click="goNpcSpawn(a.pid)"
+                >NPC刷新表</el-button
+              >
             </div>
           </el-card>
         </el-col>
@@ -407,6 +424,10 @@ function goNpcSpawn(pid) {
   router.push({ path: '/admin/npcspawns', query: { area: pid } });
 }
 
+function goNpcAdmin() {
+  router.push({ path: '/admin', query: { collection: 'npcs' } });
+}
+
 async function openCreateArea() {
   editCollection = 'mapareas';
   editId = '';
@@ -437,8 +458,8 @@ async function removeArea(area) {
   }
 }
 
-function toggleShop(pid) {
-  shopMap.value[pid] = !shopMap.value[pid];
+function toggleShop(pid, val) {
+  shopMap.value = { ...shopMap.value, [pid]: val };
 }
 
 function goCategory() {
@@ -449,5 +470,11 @@ function goCategory() {
 <style scoped>
 .page {
   padding: 20px;
+}
+.btn-row {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 4px;
+  gap: 6px;
 }
 </style>


### PR DESCRIPTION
## Summary
- show area ID and danger in map resource cards
- arrange map resource buttons vertically
- add NPC and shop controls
- keep shop toggle value and expose NPC admin shortcut
- allow Admin page collection to be set via query params

## Testing
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6888335588088322a4aa4ee63d1496b9