### PR TITLE
Improve status view

### DIFF
--- a/backend/src/services/player/actions.js
+++ b/backend/src/services/player/actions.js
@@ -236,8 +236,8 @@ async function list(user) {
   );
   const pids = users.map((u) => u.lastpid);
   const players = await Player.find(
-    { pid: { $in: pids }, uid: user._id },
-    'pid name hp',
+    { pid: { $in: pids } },
+    'pid name hp state lvl',
   );
   const map = {};
   players.forEach((p) => {
@@ -248,6 +248,8 @@ async function list(user) {
     return {
       pid: u.lastpid,
       name: p.name || '',
+      lvl: p.lvl || 0,
+      state: p.state,
       username: u.username,
       alive: p.hp > 0,
     };

--- a/frontend/src/pages/Status.vue
+++ b/frontend/src/pages/Status.vue
@@ -16,15 +16,31 @@
       </el-descriptions-item>
       <el-descriptions-item label="受伤部位">{{ injuries }}</el-descriptions-item>
     </el-descriptions>
-    <el-table :data="players" style="width: 100%; margin-top:10px">
+    <h3 style="margin-top:10px">存活玩家</h3>
+    <el-table :data="alivePlayers" style="width: 100%; margin-top:6px">
       <el-table-column prop="name" label="角色名" />
-      <el-table-column prop="username" label="用户" />
-      <el-table-column prop="alive" label="存活">
-        <template #default="scope">
-          <span>{{ scope.row.alive ? '是' : '否' }}</span>
-        </template>
+      <el-table-column prop="lvl" label="等级" width="80" />
+    </el-table>
+
+    <h3 style="margin-top:20px">死亡玩家</h3>
+    <el-table :data="deadPlayers" style="width: 100%; margin-top:6px">
+      <el-table-column prop="name" label="角色名" />
+      <el-table-column prop="lvl" label="等级" width="80" />
+      <el-table-column prop="state" label="死因" width="120">
+        <template #default="{ row }">{{ stateInfo[row.state] }}</template>
       </el-table-column>
     </el-table>
+
+    <div class="map-grid" v-if="places.value.length">
+      <div
+        v-for="area in places"
+        :key="area.pid"
+        class="grid-cell"
+        :class="{ danger: area.danger === 1, warn: area.danger === 2 }"
+      >
+        {{ area.name }}
+      </div>
+    </div>
   </div>
 </template>
 
@@ -33,9 +49,12 @@ import { ref, computed, onMounted } from 'vue'
 import { getStatus, getMapAreas, getPlayers } from '../api'
 import { playerId } from '../store/user'
 import { mapAreas as places } from '../store/map'
+import { stateInfo } from '../constants/death'
 
 const info = ref(null)
 const players = ref([])
+const alivePlayers = computed(() => players.value.filter(p => p.alive))
+const deadPlayers = computed(() => players.value.filter(p => !p.alive))
 const place = computed(() => {
   if (!info.value) return ''
   const area = places.value.find(a => a.pid === info.value.pls)
@@ -99,4 +118,8 @@ onMounted(() => {
 
 <style scoped>
 .page { padding: 20px; }
+.map-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(80px, 1fr)); gap: 6px; margin-top: 20px; }
+.grid-cell { border: 1px solid #ddd; padding: 4px; text-align: center; background: #f5f7fa; }
+.grid-cell.danger { background: #f56c6c; color: #fff; }
+.grid-cell.warn { background: #e6a23c; color: #fff; }
 </style>


### PR DESCRIPTION
## Summary
- add level and state data to player list API
- enhance status page to show alive/dead players and map grid

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68884f27d3f08322a3b66a5a01cd6d15