### PR TITLE
自动填充刷新表物品属性

### DIFF
--- a/frontend/src/pages/MapItemTable.vue
+++ b/frontend/src/pages/MapItemTable.vue
@@ -66,6 +66,17 @@ const dialogFields = ref([])
 const formData = ref({})
 let editIndex = -1
 
+function applyBaseItem() {
+  const base = items.value.find(i => i.id === formData.value.itemId)
+  if (base) {
+    if (!formData.value.itmk) formData.value.itmk = base.kind
+    if (formData.value.itme === undefined || formData.value.itme === null)
+      formData.value.itme = base.effect
+    if (!formData.value.itms) formData.value.itms = base.dur
+    if (!formData.value.itmsk) formData.value.itmsk = base.skill
+  }
+}
+
 onMounted(() => {
   fetchCategory()
   fetchItems()
@@ -144,9 +155,11 @@ function updateOptions() {
 }
 
 watch(items, updateOptions, { immediate: true })
+watch(() => formData.value.itemId, applyBaseItem, { immediate: true })
 
 async function saveDialog() {
   if (!category.value) return
+  applyBaseItem()
   if (editIndex >= 0) category.value.items.splice(editIndex, 1, { ...formData.value })
   else category.value.items.push({ ...formData.value })
   await adminUpdate('itemcategories', category.value._id, { items: category.value.items })

--- a/frontend/src/pages/MapTrapTable.vue
+++ b/frontend/src/pages/MapTrapTable.vue
@@ -66,6 +66,17 @@ const dialogFields = ref([])
 const formData = ref({})
 let editIndex = -1
 
+function applyBaseItem() {
+  const base = items.value.find(i => i.id === formData.value.itemId)
+  if (base) {
+    if (!formData.value.itmk) formData.value.itmk = base.kind
+    if (formData.value.itme === undefined || formData.value.itme === null)
+      formData.value.itme = base.effect
+    if (!formData.value.itms) formData.value.itms = base.dur
+    if (!formData.value.itmsk) formData.value.itmsk = base.skill
+  }
+}
+
 onMounted(() => {
   fetchCategory()
   fetchItems()
@@ -144,9 +155,11 @@ function updateOptions() {
 }
 
 watch(items, updateOptions, { immediate: true })
+watch(() => formData.value.itemId, applyBaseItem, { immediate: true })
 
 async function saveDialog() {
   if (!category.value) return
+  applyBaseItem()
   if (editIndex >= 0) category.value.items.splice(editIndex, 1, { ...formData.value })
   else category.value.items.push({ ...formData.value })
   await adminUpdate('itemcategories', category.value._id, { items: category.value.items })


### PR DESCRIPTION
## Summary
- 自动根据物品表为刷新表条目填充`itmk`、`itme`、`itms`、`itmsk`
- 在保存时同步应用默认值

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688855098d4083229d0addfcbc1e62df