### PR TITLE
修正NPC刷新默认配置

### DIFF
--- a/data/npcspawns.json
+++ b/data/npcspawns.json
@@ -1,3 +1,65 @@
 [
-  {"area": 0, "type": 1, "sub": 0, "num": 1, "stage": "start"}
+  {
+    "area": 0,
+    "type": 1,
+    "sub": 0,
+    "num": 1,
+    "stage": "start"
+  },
+  {
+    "area": 99,
+    "type": 2,
+    "sub": 0,
+    "num": 4,
+    "stage": "start"
+  },
+  {
+    "area": 26,
+    "type": 13,
+    "sub": 0,
+    "num": 1,
+    "stage": "start"
+  },
+  {
+    "area": 99,
+    "type": 14,
+    "sub": 0,
+    "num": 3,
+    "stage": "start"
+  },
+  {
+    "area": 34,
+    "type": 20,
+    "sub": 0,
+    "num": 36,
+    "stage": "start"
+  },
+  {
+    "area": 34,
+    "type": 21,
+    "sub": 0,
+    "num": 9,
+    "stage": "start"
+  },
+  {
+    "area": 34,
+    "type": 22,
+    "sub": 0,
+    "num": 4,
+    "stage": "start"
+  },
+  {
+    "area": 99,
+    "type": 45,
+    "sub": 0,
+    "num": 4,
+    "stage": "start"
+  },
+  {
+    "area": 32,
+    "type": 88,
+    "sub": 0,
+    "num": 4,
+    "stage": "start"
+  }
 ]

--- a/mogoDB.md/npcspawns.md
+++ b/mogoDB.md/npcspawns.md
@@ -20,10 +20,10 @@ db.npcspawns.createIndex({ area: 1 });
 db.npcspawns.createIndex({ stage: 1 });
 ```
 
-可批量导入 `data/npcspawns.json`（需自行准备）：
+可直接导入仓库附带的 `data/npcspawns.json`：
 
 ```bash
 mongoimport --db dts --collection npcspawns --file ../data/npcspawns.json --jsonArray
 ```
 
-如果希望让开局 NPC 也由刷新机制管理，可从 `data/npcs.json` 中整理 `spawnStage` 为 `start` 的 NPC，按区域(`pls`)、类型(`type`)和子类别(`sub`)汇总数量，生成 `data/npcspawns.json` 后导入。
+其中的内容已根据 `data/npcs.json` 中 `spawnStage` 为 `start` 的 NPC 汇总生成，如需重新制作，可按上述方式整理后覆盖。


### PR DESCRIPTION
## Summary
- 更新 `npcspawns.json`，根据 `npcs.json` 统计开局NPC分布
- 文档说明默认 `npcspawns.json` 已生成可直接导入

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68885f0298208322a16b63c9e82295b2