### PR TITLE
Fix table readability

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,13 +27,9 @@ const loggedIn = computed(() => !!token.value)
   </div>
 </template>
 
-<style>
-/* 引入暗色主题样式 - 这里只需要这一行！ */
-@import './styles/dark-theme.css';
-</style>
-
 <style scoped>
-@import './styles/dark-theme.css';
+/* 暗色主题暂不默认启用，如需启用可在此处引入 */
+/* @import './styles/dark-theme.css'; */
 
 .dark-nav {
   display: flex;

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -125,6 +125,7 @@
       <!-- 数据表格 -->
       <div v-else>
         <el-table
+          class="admin-table"
           :data="items"
           stripe
           border
@@ -626,6 +627,7 @@ onMounted(() => {
 </script>
 
 <style scoped>
+@import '../styles/admin-theme.css';
 .admin-page {
   min-height: 100%;
   background: #f5f7fa;

--- a/frontend/src/styles/dark-theme.css
+++ b/frontend/src/styles/dark-theme.css
@@ -425,33 +425,33 @@ html, body {
 }
 
 /* 表格 */
-.el-table {
+.dark-container .el-table {
   background: rgba(0, 0, 0, 0.4) !important;
   color: #e0e6ed !important;
 }
 
-.el-table th.el-table__cell {
+.dark-container .el-table th.el-table__cell {
   background: rgba(0, 0, 0, 0.6) !important;
   color: #00ff41 !important;
   border-bottom: 1px solid #333 !important;
 }
 
-.el-table td.el-table__cell {
+.dark-container .el-table td.el-table__cell {
   background: transparent !important;
   color: #e0e6ed !important;
   border-bottom: 1px solid #333 !important;
 }
 
-.el-table tr:hover > td {
+.dark-container .el-table tr:hover > td {
   background: rgba(0, 255, 65, 0.05) !important;
 }
 
-.el-table__empty-block {
+.dark-container .el-table__empty-block {
   background: transparent !important;
   color: #888 !important;
 }
 
-.el-table__empty-text {
+.dark-container .el-table__empty-text {
   color: #888 !important;
 }
 


### PR DESCRIPTION
## Summary
- improve dark theme table rules to apply to a dark container
- stop importing the dark theme globally
- style Admin page tables with `admin-theme.css`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688986bbcca08322adaa682bfa5cb5dd