### PR TITLE
Add dark theme to non-game pages

### DIFF
--- a/frontend/src/pages/GameOver.vue
+++ b/frontend/src/pages/GameOver.vue
@@ -45,5 +45,6 @@ onMounted(async () => {
 </script>
 
 <style scoped>
+@import '../styles/dark-theme.css';
 .page { padding: 20px; }
 </style>

--- a/frontend/src/pages/Help.vue
+++ b/frontend/src/pages/Help.vue
@@ -114,6 +114,7 @@ const areaRows = [
 </script>
 
 <style scoped>
+@import '../styles/dark-theme.css';
 .page {
   padding: 20px;
 }

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -434,6 +434,7 @@ async function logout() {
 </script>
 
 <style scoped>
+@import '../styles/dark-theme.css';
 /* 主容器居中 */
 .home-container {
   max-width: 1200px;

--- a/frontend/src/pages/Profile.vue
+++ b/frontend/src/pages/Profile.vue
@@ -48,5 +48,6 @@ const save = async () => {
 </script>
 
 <style scoped>
+@import '../styles/dark-theme.css';
 .page { padding: 20px; }
 </style>

--- a/frontend/src/pages/Start.vue
+++ b/frontend/src/pages/Start.vue
@@ -67,5 +67,6 @@ onMounted(async () => {
 </script>
 
 <style scoped>
+@import '../styles/dark-theme.css';
 .page { padding: 20px; }
 </style>

--- a/frontend/src/pages/Status.vue
+++ b/frontend/src/pages/Status.vue
@@ -59,6 +59,7 @@ onMounted(() => {
 </script>
 
 <style scoped>
+@import '../styles/dark-theme.css';
 .page { padding: 20px; }
 .map-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(80px, 1fr)); gap: 6px; margin-top: 20px; }
 .grid-cell { border: 1px solid #ddd; padding: 4px; text-align: center; background: #f5f7fa; }

--- a/frontend/src/pages/Victory.vue
+++ b/frontend/src/pages/Victory.vue
@@ -8,5 +8,6 @@
 </script>
 
 <style scoped>
+@import '../styles/dark-theme.css';
 .page { padding: 20px; }
 </style>


### PR DESCRIPTION
## Summary
- enable dark theme on non-game pages
- leave game and admin pages unaffected

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889893704388322bc54891cf1ec6809