### PR TITLE
Fix dark theme table styles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue</title>
   </head>
-  <body>
+  <body class="dark-mode">
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/frontend/src/components/AdminLayout.vue
+++ b/frontend/src/components/AdminLayout.vue
@@ -137,13 +137,13 @@ const handleCommand = (command) => {
 }
 
 .admin-header {
-  background: #fff;
-  border-bottom: 1px solid #e4e7ed;
+  background: rgba(0, 0, 0, 0.8);
+  border-bottom: 1px solid #333;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0 24px;
-  box-shadow: 0 1px 4px rgba(0, 21, 41, 0.08);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
 }
 
 .header-left {
@@ -155,7 +155,7 @@ const handleCommand = (command) => {
   margin: 0;
   font-size: 20px;
   font-weight: 600;
-  color: #1f2937;
+  color: #e0e6ed;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -168,14 +168,14 @@ const handleCommand = (command) => {
 }
 
 .admin-aside {
-  background: #fff;
-  border-right: 1px solid #e4e7ed;
+  background: rgba(0, 0, 0, 0.6);
+  border-right: 1px solid #333;
   transition: width 0.3s;
 }
 
 .aside-toggle {
   padding: 16px;
-  border-bottom: 1px solid #e4e7ed;
+  border-bottom: 1px solid #333;
   text-align: center;
 }
 
@@ -185,7 +185,7 @@ const handleCommand = (command) => {
 }
 
 .admin-main {
-  background: #f5f7fa;
+  background: transparent;
   padding: 0;
 }
 

--- a/frontend/src/components/ErrorState.vue
+++ b/frontend/src/components/ErrorState.vue
@@ -102,7 +102,8 @@ const errorDetails = computed(() => {
 }
 
 .error-stack {
-  background: #f5f7fa;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid #333;
   padding: 12px;
   border-radius: 4px;
   font-size: 12px;

--- a/frontend/src/components/InventoryPanel.vue
+++ b/frontend/src/components/InventoryPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="info">
-      <el-card
+  <el-card
         v-if="latestLog"
         class="card-section latest-log-card"
         shadow="never"
@@ -143,6 +143,7 @@ function confirmDrop() {
 <style scoped>
 .latest-log-card {
   margin-bottom: 10px;
-  background: #fdfdfd;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid #333;
 }
 </style>

--- a/frontend/src/components/LogPanel.vue
+++ b/frontend/src/components/LogPanel.vue
@@ -14,7 +14,8 @@ defineProps({
 .log-panel {
   max-height: 200px;
   overflow-y: auto;
-  background: #f9f9f9;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid #333;
   padding: 10px;
   margin-bottom: 20px;
 }

--- a/frontend/src/components/SearchDialog.vue
+++ b/frontend/src/components/SearchDialog.vue
@@ -41,6 +41,7 @@ function isEquip(kind){
   margin-bottom: 20px;
 }
 .search-result {
-  background: #fdfdfd;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid #333;
 }
 </style>

--- a/frontend/src/components/TablePanel.vue
+++ b/frontend/src/components/TablePanel.vue
@@ -309,14 +309,16 @@ watch(() => props.fieldMeta, (newFields) => {
 
 // 样式配置
 const headerCellStyle = {
-  background: '#fafafa',
-  color: '#262626',
+  background: 'rgba(0,0,0,0.6)',
+  color: '#00ff41',
   fontWeight: '600',
-  borderBottom: '1px solid #e8e8e8'
+  borderBottom: '1px solid #333'
 }
 
 const cellStyle = {
-  borderBottom: '1px solid #f0f0f0'
+  background: 'transparent',
+  color: '#e0e6ed',
+  borderBottom: '1px solid #333'
 }
 
 // 计算操作列宽度
@@ -428,7 +430,7 @@ const handleCurrentChange = (page) => {
 
 <style scoped>
 .table-panel {
-  background: #fff;
+  background: rgba(0, 0, 0, 0.4);
 }
 
 .table-toolbar {
@@ -436,7 +438,7 @@ const handleCurrentChange = (page) => {
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid #333;
   margin-bottom: 16px;
 }
 
@@ -446,7 +448,7 @@ const handleCurrentChange = (page) => {
 }
 
 .data-count {
-  color: #666;
+  color: #ccc;
   font-size: 14px;
 }
 
@@ -520,7 +522,7 @@ const handleCurrentChange = (page) => {
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid #333;
   margin-top: 16px;
 }
 
@@ -530,7 +532,7 @@ const handleCurrentChange = (page) => {
 }
 
 .selection-info {
-  color: #666;
+  color: #ccc;
   font-size: 14px;
 }
 
@@ -576,16 +578,27 @@ const handleCurrentChange = (page) => {
   padding: 16px 8px;
 }
 
+
+/* 暗色主题表格样式 */
 :deep(.el-table th.el-table__cell) {
-  background: #fafafa !important;
+  background: rgba(0, 0, 0, 0.6) !important;
+  color: #00ff41 !important;
+  border-bottom: 1px solid #333 !important;
+}
+
+:deep(.el-table td.el-table__cell) {
+  background: transparent !important;
+  color: #e0e6ed !important;
+  border-bottom: 1px solid #333 !important;
 }
 
 :deep(.el-table tr:hover > td.el-table__cell) {
-  background: #f5f7fa !important;
+  background: rgba(0, 255, 65, 0.05) !important;
 }
 
 :deep(.el-table__empty-block) {
-  background: #fff;
+  background: transparent !important;
+  color: #888 !important;
 }
 
 :deep(.el-dropdown-menu__item.active) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,6 +4,7 @@ import router from './router';
 import ElementPlus from 'element-plus';
 import 'element-plus/dist/index.css';
 import './style.css';
+import './styles/dark-theme.css';
 
 const app = createApp(App);
 app.use(router);

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -628,7 +628,7 @@ onMounted(() => {
 <style scoped>
 .admin-page {
   min-height: 100%;
-  background: #f5f7fa;
+  background: transparent;
 }
 
 .page-header {
@@ -659,7 +659,7 @@ onMounted(() => {
 .table-card {
   max-width: 1200px;
   margin: 0 auto 24px auto;
-  border: 1px solid #e4e7ed;
+  border: 1px solid #333;
 }
 
 .toolbar {
@@ -705,7 +705,7 @@ onMounted(() => {
 
 .skeleton-header {
   padding-bottom: 12px;
-  border-bottom: 1px solid #ebeef5;
+  border-bottom: 1px solid #333;
 }
 
 .empty-container {
@@ -715,7 +715,7 @@ onMounted(() => {
 .load-more {
   margin-top: 16px;
   text-align: center;
-  border-top: 1px solid #e4e7ed;
+  border-top: 1px solid #333;
   padding-top: 16px;
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -72,8 +72,8 @@ button:focus-visible {
   right: 0;
   width: 100%;
   z-index: 1000;
-  background-color: #ffffff;
-  border-bottom: 1px solid #dcdfe6;
+  background-color: #000;
+  border-bottom: 1px solid #333;
 }
 
 @media (prefers-color-scheme: light) {

--- a/frontend/src/styles/dark-theme.css
+++ b/frontend/src/styles/dark-theme.css
@@ -425,33 +425,33 @@ html, body {
 }
 
 /* 表格 */
-.el-table {
+.dark-mode .el-table {
   background: rgba(0, 0, 0, 0.4) !important;
   color: #e0e6ed !important;
 }
 
-.el-table th.el-table__cell {
+.dark-mode .el-table th.el-table__cell {
   background: rgba(0, 0, 0, 0.6) !important;
   color: #00ff41 !important;
   border-bottom: 1px solid #333 !important;
 }
 
-.el-table td.el-table__cell {
+.dark-mode .el-table td.el-table__cell {
   background: transparent !important;
   color: #e0e6ed !important;
   border-bottom: 1px solid #333 !important;
 }
 
-.el-table tr:hover > td {
+.dark-mode .el-table tr:hover > td {
   background: rgba(0, 255, 65, 0.05) !important;
 }
 
-.el-table__empty-block {
+.dark-mode .el-table__empty-block {
   background: transparent !important;
   color: #888 !important;
 }
 
-.el-table__empty-text {
+.dark-mode .el-table__empty-text {
   color: #888 !important;
 }
 


### PR DESCRIPTION
## Summary
- 应用 `dark-mode` 类以确保暗色表格样式生效
- 更新暗色主题文件，使用 `.dark-mode` 前缀覆盖 Element Plus 表格样式

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68898be4427883228296ec09e789ab29