### PR TITLE
Improve performance with caching and indexes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
+        "express-validator": "^6.15.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.16.3",
         "redis": "^5.6.0"
@@ -628,6 +629,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.15.0.tgz",
+      "integrity": "sha512-r05VYoBL3i2pswuehoFSy+uM8NBuVaY7avp5qrYjQBDzagx2Z5A77FZqPT8/gNLF3HopWkIzaTFaC4JysWXLqg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "^13.9.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1069,6 +1083,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -2051,6 +2071,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
+    "express-validator": "^6.15.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.16.3",
     "redis": "^5.6.0"

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
-const redis = require('redis');
+const redisClient = require('./config/redis');
 const cors = require('cors');
 require('dotenv').config();
 
@@ -26,8 +26,9 @@ mongoose
   })
   .catch((err) => console.error('MongoDB 连接失败', err));
 
-const redisClient = redis.createClient({ url: process.env.REDIS_URL });
-redisClient.connect().then(() => console.log('Redis 已连接'));
+
+const performanceMiddleware = require('./middlewares/performance');
+app.use(performanceMiddleware);
 
 app.get('/api/ping', (req, res) => res.json({ msg: 'pong' }));
 app.use('/api/auth', authRoutes);

--- a/backend/src/config/redis.js
+++ b/backend/src/config/redis.js
@@ -1,0 +1,6 @@
+const redis = require('redis');
+
+const client = redis.createClient({ url: process.env.REDIS_URL });
+client.connect().then(() => console.log('Redis 已连接'));
+
+module.exports = client;

--- a/backend/src/middlewares/performance.js
+++ b/backend/src/middlewares/performance.js
@@ -1,0 +1,10 @@
+module.exports = (req, res, next) => {
+  const start = Date.now();
+  res.on('finish', () => {
+    const duration = Date.now() - start;
+    if (duration > 1000) {
+      console.warn(`Slow request: ${req.method} ${req.path} took ${duration}ms`);
+    }
+  });
+  next();
+};

--- a/backend/src/middlewares/validation.js
+++ b/backend/src/middlewares/validation.js
@@ -1,0 +1,9 @@
+const { validationResult } = require('express-validator');
+
+module.exports = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+  next();
+};

--- a/backend/src/models/Chat.js
+++ b/backend/src/models/Chat.js
@@ -9,4 +9,6 @@ const chatSchema = new mongoose.Schema({
   msg: { type: String, default: '' },
 });
 
+chatSchema.index({ cid: 1, time: -1 });
+
 module.exports = mongoose.model('Chat', chatSchema);

--- a/backend/src/models/MapItem.js
+++ b/backend/src/models/MapItem.js
@@ -11,4 +11,6 @@ const mapItemSchema = new mongoose.Schema({
   stage: { type: String, default: 'start', index: true },
 });
 
+mapItemSchema.index({ pls: 1, stage: 1 });
+
 module.exports = mongoose.model('MapItem', mapItemSchema);

--- a/backend/src/models/Player.js
+++ b/backend/src/models/Player.js
@@ -126,4 +126,8 @@ const playerSchema = new mongoose.Schema({
   nskillpara: { type: String, default: '' },
 });
 
+playerSchema.index({ pid: 1, uid: 1 });
+playerSchema.index({ pls: 1, hp: 1, type: 1 });
+playerSchema.index({ type: 1, state: 1 });
+
 module.exports = mongoose.model('Player', playerSchema);

--- a/backend/src/routes/game.js
+++ b/backend/src/routes/game.js
@@ -4,6 +4,8 @@ const gameController = require('../controllers/gameController');
 const playerController = require('../controllers/playerController');
 const chatController = require('../controllers/chatController');
 const auth = require('../middlewares/auth');
+const validate = require('../middlewares/validation');
+const { body } = require('express-validator');
 
 router.get('/info', gameController.getInfo);
 router.post('/start', gameController.startGame);
@@ -25,7 +27,13 @@ router.post('/pickequip', auth, playerController.pickEquip);
 router.post('/use', auth, playerController.useItem);
 router.post('/equip', auth, playerController.equip);
 router.post('/unequip', auth, playerController.unequip);
-router.post('/attack', auth, playerController.attack);
+router.post(
+  '/attack',
+  auth,
+  [body('pid').isInt().withMessage('Invalid player ID'), body('eid').isInt().withMessage('Invalid enemy ID')],
+  validate,
+  playerController.attack,
+);
 router.post('/escape', auth, playerController.escape);
 router.post('/drop', auth, playerController.dropItem);
 router.post('/dropequip', auth, playerController.dropEquip);

--- a/backend/src/services/cacheService.js
+++ b/backend/src/services/cacheService.js
@@ -1,0 +1,19 @@
+const redis = require('../config/redis');
+
+class CacheService {
+  async get(key) {
+    const data = await redis.get(key);
+    return data ? JSON.parse(data) : null;
+  }
+
+  async set(key, value, ttl = 300) {
+    await redis.setEx(key, ttl, JSON.stringify(value));
+  }
+
+  async invalidate(pattern) {
+    const keys = await redis.keys(pattern);
+    if (keys.length) await redis.del(keys);
+  }
+}
+
+module.exports = new CacheService();

--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -11,6 +11,7 @@ const NpcSpawn = require('../models/NpcSpawn');
 const Club = require('../models/Club');
 const Chat = require('../models/Chat');
 const constants = require('../config/constants');
+const cache = require('./cacheService');
 const fs = require('fs');
 const path = require('path');
 
@@ -287,6 +288,8 @@ async function stopGame() {
 }
 
 async function mapAreas() {
+  const cached = await cache.get('map:areas');
+  if (cached) return cached;
   const [areas, info] = await Promise.all([
     MapArea.find({}, 'pid name danger').sort({ pid: 1 }),
     GameInfo.findOne(),
@@ -311,6 +314,7 @@ async function mapAreas() {
       }
     }
   }
+  await cache.set('map:areas', res, 600);
   return res;
 }
 
@@ -373,6 +377,7 @@ async function checkGameOver() {
 
 async function openArea(pid) {
   await MapArea.updateOne({ pid }, { danger: 1 });
+  await cache.invalidate('map:areas');
   const info = await GameInfo.findOne();
   if (info) {
     info.areanum = await MapArea.countDocuments({ danger: 1 });
@@ -382,6 +387,7 @@ async function openArea(pid) {
 
 async function closeArea(pid) {
   await MapArea.updateOne({ pid }, { danger: 0 });
+  await cache.invalidate('map:areas');
   const info = await GameInfo.findOne();
   if (info) {
     info.areanum = await MapArea.countDocuments({ danger: 1 });

--- a/backend/src/services/player/fight.js
+++ b/backend/src/services/player/fight.js
@@ -1,6 +1,7 @@
 const Player = require('../../models/Player');
 const GameInfo = require('../../models/GameInfo');
 const Log = require('../../models/Log');
+const mongoose = require('mongoose');
 const constants = require('../../config/constants');
 const { checkDangerAreas } = require('../gameService');
 const clubPro = require('../../config/clubProficiency');
@@ -8,6 +9,7 @@ const clubPro = require('../../config/clubProficiency');
 const playerUtils = require('./utils');
 const { applyRest, restoreMemoryItem, formatPlayer } = playerUtils;
 const combat = require('./combat');
+const { NotFoundError, ValidationError } = require('../../utils/errors');
 
 // 武器系别到熟练度字段的映射
 const SKILL_FIELDS = {
@@ -224,51 +226,34 @@ function collectItems(target) {
 }
 
 async function attack(user, body) {
-  const { pid, eid } = body;
-  await checkDangerAreas();
-  const info = await GameInfo.findOne();
-  if (!info || info.gamestate < constants.get('START_THRESHOLD')) {
-    const err = new Error('游戏未开始');
-    err.status = 400;
-    throw err;
-  }
-  const player = await Player.findOne({ pid, uid: user._id });
-  if (!player) {
-    const err = new Error('玩家不存在');
-    err.status = 404;
-    throw err;
-  }
-  if (player.hp <= 0) {
-    const err = new Error('你已经死亡');
-    err.status = 400;
-    throw err;
-  }
-  const enemy = await Player.findOne({ pid: eid });
-  if (!enemy) {
-    const err = new Error('目标不存在');
-    err.status = 404;
-    throw err;
-  }
-  if (enemy.hp <= 0) {
-    const err = new Error('目标已死亡');
-    err.status = 400;
-    throw err;
-  }
-  const memory = player.enemymemory ? JSON.parse(player.enemymemory) : null;
-  if (!memory || memory.id !== eid) {
-    const err = new Error('当前没有与该目标交战');
-    err.status = 400;
-    throw err;
-  }
-  await restoreMemoryItem(player);
-  applyRest(player);
-  const cost = constants.get('ATTACK_SP_COST');
-  if (player.sp < cost) {
-    const err = new Error('体力不足，不能攻击');
-    err.status = 400;
-    throw err;
-  }
-  player.sp -= cost;
+  const session = await mongoose.startSession();
+  session.startTransaction();
+  try {
+    const { pid, eid } = body;
+    await checkDangerAreas();
+    const info = await GameInfo.findOne().session(session);
+    if (!info || info.gamestate < constants.get('START_THRESHOLD')) {
+      throw new ValidationError('游戏未开始');
+    }
+    const [player, enemy] = await Promise.all([
+      Player.findOne({ pid, uid: user._id }).session(session),
+      Player.findOne({ pid: eid }).session(session),
+    ]);
+    if (!player) throw new NotFoundError('玩家不存在');
+    if (player.hp <= 0) throw new ValidationError('你已经死亡');
+    if (!enemy) throw new NotFoundError('目标不存在');
+    if (enemy.hp <= 0) throw new ValidationError('目标已死亡');
+    const memory = player.enemymemory ? JSON.parse(player.enemymemory) : null;
+    if (!memory || memory.id !== eid) {
+      throw new ValidationError('当前没有与该目标交战');
+    }
+    await restoreMemoryItem(player);
+    applyRest(player);
+    const cost = constants.get('ATTACK_SP_COST');
+    if (player.sp < cost) {
+      throw new ValidationError('体力不足，不能攻击');
+    }
+    player.sp -= cost;
   let log = '';
 
   const r1 = calcDamage(player, enemy);
@@ -308,13 +293,20 @@ async function attack(user, body) {
   }
 
   const time = Math.floor(Date.now() / 1000);
-  await Log.create([
-    { toid: player.pid, type: 'b', time, log },
-    { toid: enemy.pid, type: 'b', time, log },
-  ]);
-  if (!loot) player.enemymemory = '';
-  enemy.enemymemory = '';
-  await Promise.all([player.save(), enemy.save()]);
+    await Log.create(
+      [
+        { toid: player.pid, type: 'b', time, log },
+        { toid: enemy.pid, type: 'b', time, log },
+      ],
+      { session },
+    );
+    if (!loot) player.enemymemory = '';
+    enemy.enemymemory = '';
+    await Promise.all([
+      player.save({ session }),
+      enemy.save({ session }),
+    ]);
+    await session.commitTransaction();
   const ret = {
     log,
     player: formatPlayer(player),
@@ -330,7 +322,13 @@ async function attack(user, body) {
     },
   };
   if (loot) ret.loot = loot;
-  return ret;
+    return ret;
+  } catch (error) {
+    await session.abortTransaction();
+    throw error;
+  } finally {
+    session.endSession();
+  }
 }
 
 async function escape(user, body) {

--- a/backend/src/utils/errors.js
+++ b/backend/src/utils/errors.js
@@ -1,0 +1,24 @@
+class GameError extends Error {
+  constructor(message, status = 500) {
+    super(message);
+    this.status = status;
+  }
+}
+
+class NotFoundError extends GameError {
+  constructor(message = '资源不存在') {
+    super(message, 404);
+  }
+}
+
+class ValidationError extends GameError {
+  constructor(message = '参数错误') {
+    super(message, 400);
+  }
+}
+
+module.exports = {
+  GameError,
+  NotFoundError,
+  ValidationError,
+};

--- a/mogoDB.md/chats.md
+++ b/mogoDB.md/chats.md
@@ -11,3 +11,11 @@ db.chats.insertMany([
 ```
 
 字段含义与 `backend/src/models/Chat.js` 完全一致。
+
+## 推荐索引
+
+按照聊天编号和时间建立复合索引，以便按时间倒序查询：
+
+```javascript
+db.chats.createIndex({ cid: 1, time: -1 });
+```

--- a/mogoDB.md/mapitems.md
+++ b/mogoDB.md/mapitems.md
@@ -20,8 +20,8 @@ mongoimport --db dts --collection mapitems --file ../data/mapitems.json --jsonAr
 
 以上字段对齐 `backend/src/models/MapItem.js`，仅为示例可按需调整。
 
-在 MongoDB shell 中可以为 `stage` 字段建立索引：
+在 MongoDB shell 中可以为位置和阶段建立复合索引：
 
 ```javascript
-db.mapitems.createIndex({ stage: 1 });
+db.mapitems.createIndex({ pls: 1, stage: 1 });
 ```

--- a/mogoDB.md/players.md
+++ b/mogoDB.md/players.md
@@ -39,3 +39,13 @@ db.players.updateMany(
 ```
 
 该字段对应 `backend/src/models/Player.js` 中的 `enemymemory`。
+
+## 新增复合索引
+
+为提升查询效率，在 `players` 集合创建以下索引：
+
+```javascript
+db.players.createIndex({ pid: 1, uid: 1 });
+db.players.createIndex({ pls: 1, hp: 1, type: 1 });
+db.players.createIndex({ type: 1, state: 1 });
+```


### PR DESCRIPTION
## Summary
- add Redis config and cache service
- add validation and performance middlewares
- create custom error classes
- batch player queries with transaction
- cache map areas and invalidate on area change
- add composite indexes for Player, MapItem and Chat models
- document new indexes in `mogoDB.md`
- apply request validation for attack route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6889ca6ae1b883228970d2c2ff943234