### PR TITLE
增强性能与安全的后端改进

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,10 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "compression": "^1.7.4",
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.0.0",
         "express-validator": "^6.15.0",
+        "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.16.3",
         "redis": "^5.6.0"
@@ -381,6 +384,60 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -627,6 +684,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express-validator": {
@@ -886,6 +958,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -1529,6 +1610,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,10 @@
     "express-validator": "^6.15.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.16.3",
-    "redis": "^5.6.0"
+    "redis": "^5.6.0",
+    "compression": "^1.7.4",
+    "express-rate-limit": "^7.0.0",
+    "helmet": "^7.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,6 +2,9 @@ const express = require('express');
 const mongoose = require('mongoose');
 const redisClient = require('./config/redis');
 const cors = require('cors');
+const compression = require('compression');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 require('dotenv').config();
 
 const authRoutes = require('./routes/auth');
@@ -14,6 +17,10 @@ const constantsService = require('./services/constantsService');
 const app = express();
 app.use(cors());
 app.use(express.json());
+app.use(helmet());
+app.use(compression());
+const limiter = rateLimit({ windowMs: 60 * 1000, max: 100 });
+app.use(limiter);
 
 const mongoUri = process.env.MONGODB_URI;
 mongoose

--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -19,4 +19,7 @@ module.exports = {
   get WEATHER_ACTIVE_OBBS() {
     return constantsService.get('WEATHER_ACTIVE_OBBS');
   },
+  get SLOW_REQUEST_THRESHOLD() {
+    return constantsService.get('SLOW_REQUEST_THRESHOLD');
+  },
 };

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -21,7 +21,7 @@ exports.register = async (req, res) => {
     if (!username || !password) {
       return res.status(400).json({ msg: '用户名和密码不能为空' });
     }
-    const exists = await User.findOne({ username });
+    const exists = await User.findOne({ username }).lean();
     if (exists) {
       return res.status(400).json({ msg: '用户名已存在' });
     }
@@ -77,7 +77,7 @@ exports.refresh = async (req, res) => {
       return res.status(400).json({ msg: '缺少刷新令牌' });
     }
     const payload = jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET);
-    const user = await User.findById(payload.id);
+    const user = await User.findById(payload.id).lean();
     if (!user || user.refreshToken !== refreshToken) {
       return res.status(401).json({ msg: '刷新令牌无效' });
     }
@@ -106,7 +106,7 @@ exports.logout = async (req, res) => {
       }
     }
     if (uid) {
-      const user = await User.findById(uid);
+      const user = await User.findById(uid).lean();
       if (user && user.lastpid) {
         await Player.updateOne(
           { pid: user.lastpid, uid },

--- a/backend/src/controllers/gameController.js
+++ b/backend/src/controllers/gameController.js
@@ -1,4 +1,3 @@
-const GameInfo = require('../models/GameInfo');
 const Player = require('../models/Player');
 const History = require('../models/History');
 const gameService = require('../services/gameService');
@@ -7,7 +6,7 @@ exports.getInfo = async (req, res) => {
   try {
     await gameService.checkDangerAreas();
     await gameService.checkGameOver();
-    const info = await GameInfo.findOne();
+    const info = await gameService.getGameInfo();
     if (info) {
       const [validnum, alivenum] = await Promise.all([
         Player.countDocuments({ type: 0 }),

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -12,7 +12,7 @@ exports.updateProfile = async (req, res) => {
     const user = req.user;
     // change username
     if (username && username !== user.username) {
-      const exists = await User.findOne({ username });
+      const exists = await User.findOne({ username }).lean();
       if (exists) return res.status(400).json({ msg: '用户名已存在' });
       user.username = username;
     }

--- a/backend/src/middlewares/performance.js
+++ b/backend/src/middlewares/performance.js
@@ -1,8 +1,10 @@
+const constants = require('../config/constants');
+
 module.exports = (req, res, next) => {
   const start = Date.now();
   res.on('finish', () => {
     const duration = Date.now() - start;
-    if (duration > 1000) {
+    if (duration > constants.SLOW_REQUEST_THRESHOLD) {
       console.warn(`Slow request: ${req.method} ${req.path} took ${duration}ms`);
     }
   });

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -6,8 +6,8 @@ const userSchema = new mongoose.Schema({
   avatar: { type: String, default: '' },
   role: { type: String, default: 'user' },
   refreshToken: { type: String, default: '' },
-  lastgame: { type: Number, default: 0 },
-  lastpid: { type: Number, default: 0 },
+  lastgame: { type: Number, default: 0, index: true },
+  lastpid: { type: Number, default: 0, index: true },
   createdAt: { type: Date, default: Date.now },
 });
 

--- a/backend/src/services/chatService.js
+++ b/backend/src/services/chatService.js
@@ -4,7 +4,7 @@ const Player = require('../models/Player');
 async function list(query) {
   let lastcid = Number(query.lastcid) || 0;
   const filter = lastcid ? { cid: { $gt: lastcid } } : {};
-  const chats = await Chat.find(filter).sort({ cid: 1 }).limit(50);
+  const chats = await Chat.find(filter).sort({ cid: 1 }).limit(50).lean();
   const newLast = chats.length ? chats[chats.length - 1].cid : lastcid;
   return { lastcid: newLast, chats };
 }
@@ -16,13 +16,13 @@ async function send(user, body) {
     err.status = 400;
     throw err;
   }
-  const player = await Player.findOne({ pid, uid: user._id });
+  const player = await Player.findOne({ pid, uid: user._id }).lean();
   if (!player) {
     const err = new Error('玩家不存在');
     err.status = 404;
     throw err;
   }
-  const last = await Chat.findOne().sort({ cid: -1 });
+  const last = await Chat.findOne().sort({ cid: -1 }).lean();
   const cid = last ? last.cid + 1 : 1;
   const chat = await Chat.create({
     cid,

--- a/backend/src/services/constantsService.js
+++ b/backend/src/services/constantsService.js
@@ -13,10 +13,11 @@ const cache = {
   CRIT_BASE_RATE: 0.05,
   DODGE_BASE_RATE: 0.05,
   CRIT_MULTIPLIER: 1.5,
+  SLOW_REQUEST_THRESHOLD: 1000,
 };
 
 async function loadConstants() {
-  const list = await Constant.find({});
+  const list = await Constant.find({}).lean();
   list.forEach((c) => {
     cache[c.key] = c.value;
   });

--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -39,6 +39,14 @@ async function ensureGameInfo() {
   }
 }
 
+async function getGameInfo() {
+  const cached = await cache.get('game:info');
+  if (cached) return cached;
+  const info = await GameInfo.findOne().lean();
+  if (info) await cache.set('game:info', info, 5);
+  return info;
+}
+
 async function generateItemsFromCategories(type, stage = 'start') {
   const categories = await ItemCategory.find({ type });
   const map = {};
@@ -199,6 +207,7 @@ async function startGame() {
     recv: '',
     msg: '游戏开始！',
   });
+  await cache.invalidate('game:info');
 
   return { msg: '游戏已开始', gamestate: info.gamestate };
 }
@@ -284,6 +293,7 @@ async function stopGame() {
   } catch (e) {
     console.error('清理玩家数据失败', e);
   }
+  await cache.invalidate('game:info');
   return { msg: '游戏已停止', gamestate: info.gamestate };
 }
 
@@ -291,8 +301,8 @@ async function mapAreas() {
   const cached = await cache.get('map:areas');
   if (cached) return cached;
   const [areas, info] = await Promise.all([
-    MapArea.find({}, 'pid name danger').sort({ pid: 1 }),
-    GameInfo.findOne(),
+    MapArea.find({}, 'pid name danger').sort({ pid: 1 }).lean(),
+    GameInfo.findOne().lean(),
   ]);
   const res = areas.map((a) => ({
     pid: a.pid,
@@ -408,4 +418,5 @@ module.exports = {
   spawnNpcs,
   spawnMapItems,
   spawnMapTraps,
+  getGameInfo,
 };

--- a/backend/src/services/player/entry.js
+++ b/backend/src/services/player/entry.js
@@ -7,13 +7,13 @@ const { checkDangerAreas } = require('../gameService');
 const clubPro = require('../../config/clubProficiency');
 
 async function clubs() {
-  const clubs = await Club.find({}, 'cid name');
+  const clubs = await Club.find({}, 'cid name').lean();
   return clubs;
 }
 
 async function enter(user, body) {
   await checkDangerAreas();
-  const info = await GameInfo.findOne();
+  const info = await GameInfo.findOne().lean();
   if (!info || info.gamestate < constants.get('START_THRESHOLD')) {
     const err = new Error('游戏未开始');
     err.status = 400;
@@ -23,16 +23,16 @@ async function enter(user, body) {
 
   let player = null;
   if (user.lastgame === gid && user.lastpid) {
-    player = await Player.findOne({ pid: user.lastpid, uid: user._id });
+    player = await Player.findOne({ pid: user.lastpid, uid: user._id }).lean();
   }
 
   if (!player) {
-    const last = await Player.findOne().sort({ pid: -1 });
+    const last = await Player.findOne().sort({ pid: -1 }).lean();
     const pid = last ? last.pid + 1 : 1;
     const { club } = body;
     let base = { hp: 100, sp: 200, att: 0, def: 0, money: 20 };
     if (club) {
-      const c = await Club.findOne({ cid: club });
+      const c = await Club.findOne({ cid: club }).lean();
       if (c) {
         base.hp += c.hp;
         base.sp += c.sp;
@@ -85,8 +85,8 @@ async function enter(user, body) {
     }
 
     try {
-      const startItems = await Item.find({ kind: { $not: /^W/ } });
-      const startWeps = await Item.find({ kind: /^W/ });
+      const startItems = await Item.find({ kind: { $not: /^W/ } }).lean();
+      const startWeps = await Item.find({ kind: /^W/ }).lean();
 
       const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
 

--- a/mogoDB.md/README.md
+++ b/mogoDB.md/README.md
@@ -7,7 +7,11 @@
 2. 切换数据库：`use dts`
 3. 为 `users` 集合创建唯一索引：
    ```javascript
-   db.users.createIndex({ username: 1 }, { unique: true })
+  db.users.createIndex({ username: 1 }, { unique: true })
+  ```
+4. 为 `lastgame` 与 `lastpid` 字段创建复合索引：
+   ```javascript
+   db.users.createIndex({ lastgame: 1, lastpid: 1 })
    ```
 
 ## 初始管理员账号

--- a/mogoDB.md/constants.md
+++ b/mogoDB.md/constants.md
@@ -31,3 +31,14 @@ db.constants.insertMany([
 ```
 
 若集合中已存在同名键，可通过 `updateOne` 调整对应数值。
+
+## 新增慢请求警告阈值
+
+用于性能监控的中间件依赖 `SLOW_REQUEST_THRESHOLD` 常量，单位为毫秒：
+
+```javascript
+use dts;
+db.constants.insertOne({ key: 'SLOW_REQUEST_THRESHOLD', value: 1000 });
+```
+
+可根据需求调整阈值大小后重启服务生效。


### PR DESCRIPTION
## 概要
- 为 `users` 集合的 `lastgame`、`lastpid` 字段添加索引
- 新增 `SLOW_REQUEST_THRESHOLD` 常量并在性能中间件中使用
- 引入 `compression`、`helmet`、`express-rate-limit` 中间件
- 多处查询使用 `lean()` 提升只读性能
- 更新 MongoDB 操作文档说明

## 测试
- `npm test` *(预期失败：无测试脚本)*

------
https://chatgpt.com/codex/tasks/task_e_6889ce4c37108322bc248eb227336661