### PR TITLE
Fix game info update on /info API

### DIFF
--- a/backend/src/controllers/gameController.js
+++ b/backend/src/controllers/gameController.js
@@ -1,5 +1,7 @@
 const Player = require('../models/Player');
 const History = require('../models/History');
+const GameInfo = require('../models/GameInfo');
+const cache = require('../services/cacheService');
 const gameService = require('../services/gameService');
 
 exports.getInfo = async (req, res) => {
@@ -13,12 +15,9 @@ exports.getInfo = async (req, res) => {
         Player.countDocuments({ type: 0, hp: { $gt: 0 } }),
       ]);
       const deathnum = validnum - alivenum;
-      info.validnum = validnum;
-      info.alivenum = alivenum;
-      info.deathnum = deathnum;
-      await info.save();
-      const data = info.toObject();
-      data.now = Date.now();
+      await GameInfo.updateOne({}, { validnum, alivenum, deathnum });
+      await cache.invalidate('game:info');
+      const data = { ...info, validnum, alivenum, deathnum, now: Date.now() };
       res.json(data);
     } else {
       res.json({});


### PR DESCRIPTION
## Summary
- update `getInfo` controller to handle lean gameInfo objects
- persist player counts with `GameInfo.updateOne` and invalidate cache

## Testing
- `npx prettier -w backend/src/controllers/gameController.js`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6889d35e33ac8322b32c805dd3e7f2d8