### PR TITLE
Add item crafting system

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -30,6 +30,7 @@ mongoose
     await constantsService.loadConstants();
     await gameService.ensureDefaultClubs();
     await gameService.ensureGameInfo();
+    await gameService.ensureDefaultRecipes();
   })
   .catch((err) => console.error('MongoDB 连接失败', err));
 

--- a/backend/src/controllers/playerController.js
+++ b/backend/src/controllers/playerController.js
@@ -87,3 +87,7 @@ exports.dropEquip = (req, res) => {
 exports.lootItem = (req, res) => {
   handle(() => playerService.lootItem(req.user, req.body), req, res);
 };
+
+exports.craft = (req, res) => {
+  handle(() => playerService.craft(req.user, req.body), req, res);
+};

--- a/backend/src/fieldsMeta.js
+++ b/backend/src/fieldsMeta.js
@@ -235,4 +235,13 @@ module.exports = {
     { name: 'name', label: '区域名', type: 'text' },
     { name: 'players', label: '玩家列表', type: 'text' },
   ],
+  craftrecipes: [
+    { name: 'materials', label: '材料列表', type: 'array' },
+    { name: 'materialHash', label: '材料哈希', type: 'text' },
+    { name: 'result.name', label: '产物名称', type: 'text' },
+    { name: 'result.kind', label: '产物类型', type: 'text' },
+    { name: 'result.effect', label: '产物效果', type: 'number' },
+    { name: 'result.dur', label: '产物耐久', type: 'text' },
+    { name: 'result.skill', label: '产物属性', type: 'text' },
+  ],
 };

--- a/backend/src/models/CraftRecipe.js
+++ b/backend/src/models/CraftRecipe.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const craftRecipeSchema = new mongoose.Schema({
+  materials: [{ type: String, required: true }], // 材料名称数组，已排序
+  materialHash: { type: String, unique: true, index: true }, // 材料组合的哈希值
+  result: {
+    name: { type: String, required: true },
+    kind: { type: String, required: true },
+    effect: { type: Number, default: 0 },
+    dur: { type: String, default: '1' },
+    skill: { type: String, default: '' },
+  },
+});
+
+// 生成材料组合的哈希值
+craftRecipeSchema.statics.generateHash = function generateHash(materials) {
+  return materials.sort().join('|');
+};
+
+module.exports = mongoose.model('CraftRecipe', craftRecipeSchema);

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -22,6 +22,7 @@ const models = {
   gameinfos: require('../models/GameInfo'),
   users: require('../models/User'),
   npcspawns: require('../models/NpcSpawn'),
+  craftrecipes: require('../models/CraftRecipe'),
 };
 
 router.use(auth);

--- a/backend/src/routes/game.js
+++ b/backend/src/routes/game.js
@@ -38,6 +38,7 @@ router.post('/escape', auth, playerController.escape);
 router.post('/drop', auth, playerController.dropItem);
 router.post('/dropequip', auth, playerController.dropEquip);
 router.post('/loot', auth, playerController.lootItem);
+router.post('/craft', auth, playerController.craft);
 
 router.get('/chat', auth, chatController.list);
 router.post('/chat', auth, chatController.send);

--- a/backend/src/services/gameService.js
+++ b/backend/src/services/gameService.js
@@ -10,6 +10,7 @@ const ItemCategory = require('../models/ItemCategory');
 const NpcSpawn = require('../models/NpcSpawn');
 const Club = require('../models/Club');
 const Chat = require('../models/Chat');
+const CraftRecipe = require('../models/CraftRecipe');
 const constants = require('../config/constants');
 const cache = require('./cacheService');
 const fs = require('fs');
@@ -37,6 +38,31 @@ async function ensureGameInfo() {
   if (count === 0) {
     await GameInfo.create({});
     console.log('已初始化游戏信息');
+  }
+}
+
+async function ensureDefaultRecipes() {
+  const count = await CraftRecipe.countDocuments();
+  if (count === 0) {
+    const recipes = [
+      {
+        materials: ['面包', '矿泉水'],
+        result: { name: '简易便当', kind: 'HB', effect: 150, dur: '1', skill: '' },
+      },
+      {
+        materials: ['小刀', '磨刀石'],
+        result: { name: '锋利的小刀', kind: 'WK', effect: 50, dur: '30', skill: '' },
+      },
+      {
+        materials: ['木棍', '铁钉', '胶带'],
+        result: { name: '钉棍', kind: 'WP', effect: 45, dur: '25', skill: '' },
+      },
+    ];
+    for (const r of recipes) {
+      r.materialHash = CraftRecipe.generateHash(r.materials);
+      await CraftRecipe.create(r);
+    }
+    console.log('已导入默认合成配方');
   }
 }
 
@@ -409,6 +435,7 @@ async function closeArea(pid) {
 module.exports = {
   ensureDefaultClubs,
   ensureGameInfo,
+  ensureDefaultRecipes,
   startGame,
   stopGame,
   mapAreas,

--- a/backend/src/services/player/crafting.js
+++ b/backend/src/services/player/crafting.js
@@ -1,0 +1,87 @@
+const Player = require('../../models/Player');
+const CraftRecipe = require('../../models/CraftRecipe');
+const { formatPlayer } = require('./utils');
+
+async function craft(user, body) {
+  const { pid, itemIndices } = body; // 选中的物品索引数组
+
+  if (!Array.isArray(itemIndices) || itemIndices.length < 2 || itemIndices.length > 5) {
+    const err = new Error('请选择2-5个物品进行合成');
+    err.status = 400;
+    throw err;
+  }
+
+  const player = await Player.findOne({ pid, uid: user._id });
+  if (!player) {
+    const err = new Error('玩家不存在');
+    err.status = 404;
+    throw err;
+  }
+
+  if (player.hp <= 0) {
+    const err = new Error('你已经死亡');
+    err.status = 400;
+    throw err;
+  }
+
+  const materials = [];
+  const validIndices = [];
+  for (const idx of itemIndices) {
+    if (idx >= 0 && idx < 7) {
+      const itemName = player[`itm${idx}`];
+      if (itemName) {
+        materials.push(itemName);
+        validIndices.push(idx);
+      }
+    }
+  }
+
+  if (materials.length < 2) {
+    const err = new Error('有效物品不足，无法合成');
+    err.status = 400;
+    throw err;
+  }
+
+  const materialHash = CraftRecipe.generateHash(materials);
+  const recipe = await CraftRecipe.findOne({ materialHash });
+  if (!recipe) {
+    const err = new Error('没有找到对应的合成配方');
+    err.status = 400;
+    throw err;
+  }
+
+  let emptySlot = -1;
+  for (let i = 0; i < 7; i++) {
+    if (!player[`itm${i}`]) {
+      emptySlot = i;
+      break;
+    }
+  }
+  if (emptySlot === -1) {
+    emptySlot = validIndices[0];
+  }
+
+  for (const idx of validIndices) {
+    player[`itm${idx}`] = '';
+    player[`itmk${idx}`] = '';
+    player[`itme${idx}`] = 0;
+    player[`itms${idx}`] = '0';
+    player[`itmsk${idx}`] = '';
+  }
+
+  player[`itm${emptySlot}`] = recipe.result.name;
+  player[`itmk${emptySlot}`] = recipe.result.kind;
+  player[`itme${emptySlot}`] = recipe.result.effect;
+  player[`itms${emptySlot}`] = recipe.result.dur;
+  player[`itmsk${emptySlot}`] = recipe.result.skill;
+
+  await player.save();
+  return {
+    success: true,
+    message: `合成成功！获得了${recipe.result.name}`,
+    result: recipe.result,
+    player: formatPlayer(player),
+  };
+}
+
+module.exports = { craft };

--- a/backend/src/services/playerService.js
+++ b/backend/src/services/playerService.js
@@ -4,4 +4,5 @@ module.exports = {
   ...require('./player/items'),
   ...require('./player/loot'),
   ...require('./player/fight'),
+  ...require('./player/crafting'),
 };

--- a/frontend/src/api/game.js
+++ b/frontend/src/api/game.js
@@ -32,6 +32,8 @@ export const dropEquip = (pid, slot) =>
   api.post('/game/dropequip', { pid, slot });
 export const lootCorpse = (pid, corpseId, slot) =>
   api.post('/game/loot', { pid, corpseId, slot });
+export const craftItem = (pid, indices) =>
+  api.post('/game/craft', { pid, itemIndices: indices });
 
 export const getChats = (params) => api.get('/game/chat', { params });
 export const sendChat = (data) => api.post('/game/chat', data);

--- a/frontend/src/components/ActionBar.vue
+++ b/frontend/src/components/ActionBar.vue
@@ -2,11 +2,12 @@
   <div class="action-bar">
     <el-button @click="$emit('search')">搜索</el-button>
     <el-button @click="$emit('rest')">休息</el-button>
+    <el-button @click="$emit('craft')">合成</el-button>
   </div>
 </template>
 
 <script setup>
-const emit = defineEmits(['search','rest'])
+const emit = defineEmits(['search','rest','craft'])
 </script>
 
 <style scoped>

--- a/frontend/src/components/CraftDialog.vue
+++ b/frontend/src/components/CraftDialog.vue
@@ -1,0 +1,39 @@
+<template>
+  <el-dialog v-model="visible" title="物品合成" width="400px" @close="$emit('close')">
+    <el-table :data="bagItems" @selection-change="selected = $event" style="width:100%">
+      <el-table-column type="selection" width="40" />
+      <el-table-column prop="name" label="物品" />
+      <el-table-column prop="type" label="类型" width="90" />
+      <el-table-column prop="effect" label="效果" width="70" />
+      <el-table-column prop="uses" label="耐久" width="60" />
+    </el-table>
+    <template #footer>
+      <span class="dialog-footer">
+        <el-button @click="$emit('close')">取消</el-button>
+        <el-button type="primary" @click="confirm" :disabled="selected.length < 2">合成</el-button>
+      </span>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  modelValue: Boolean,
+  bagItems: { type: Array, default: () => [] }
+})
+const emit = defineEmits(['update:modelValue','confirm','close'])
+const visible = computed({
+  get: () => props.modelValue,
+  set: v => emit('update:modelValue', v)
+})
+const selected = ref([])
+
+function confirm(){
+  emit('confirm', selected.value)
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/pages/CraftRecipeAdmin.vue
+++ b/frontend/src/pages/CraftRecipeAdmin.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="page">
+    <h2>合成配方管理</h2>
+    <el-button type="primary" size="small" @click="openCreate">新建</el-button>
+    <el-table :data="recipes" style="margin-top:10px" @row-click="openEdit">
+      <el-table-column prop="materials" label="材料" />
+      <el-table-column prop="result.name" label="产物" />
+      <el-table-column label="操作" width="120">
+        <template #default="{ row }">
+          <el-button size="small" type="danger" @click.stop="remove(row)">删除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+    <FormDialog
+      v-model="dialogVisible"
+      :title="dialogTitle"
+      :fields="fields"
+      :form="formData"
+      @save="save"
+      @close="dialogVisible=false"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { adminList, adminCreate, adminUpdate, adminDelete } from '../api'
+import FormDialog from '../components/FormDialog.vue'
+
+const recipes = ref([])
+const dialogVisible = ref(false)
+const dialogTitle = ref('')
+const formData = ref({})
+const editId = ref('')
+
+const fields = [
+  { name: 'materials', label: '材料列表', type: 'text' },
+  { name: 'result.name', label: '产物名称', type: 'text' },
+  { name: 'result.kind', label: '产物类型', type: 'text' },
+  { name: 'result.effect', label: '产物效果', type: 'number' },
+  { name: 'result.dur', label: '产物耐久', type: 'text' },
+  { name: 'result.skill', label: '产物属性', type: 'text' }
+]
+
+onMounted(fetchRecipes)
+
+async function fetchRecipes() {
+  try {
+    const { data } = await adminList('craftrecipes')
+    recipes.value = data
+  } catch (e) {
+    alert(e.response?.data?.msg || '加载失败')
+  }
+}
+
+function openEdit(row) {
+  editId.value = row._id
+  dialogTitle.value = '编辑'
+  formData.value = { ...row, materials: row.materials.join(',') }
+  dialogVisible.value = true
+}
+
+function openCreate() {
+  dialogTitle.value = '新建'
+  formData.value = { materials: '', result: { name: '', kind: '', effect: 0, dur: '1', skill: '' } }
+  editId.value = ''
+  dialogVisible.value = true
+}
+
+async function save() {
+  const data = { ...formData.value, materials: formData.value.materials.split(',').map(s => s.trim()) }
+  data.materialHash = data.materials.sort().join('|')
+  try {
+    if (editId.value) {
+      await adminUpdate('craftrecipes', editId.value, data)
+    } else {
+      await adminCreate('craftrecipes', data)
+    }
+    dialogVisible.value = false
+    fetchRecipes()
+  } catch (e) {
+    alert(e.response?.data?.msg || '保存失败')
+  }
+}
+
+async function remove(row) {
+  if (!confirm('确定删除？')) return
+  try {
+    await adminDelete('craftrecipes', row._id)
+    fetchRecipes()
+  } catch (e) {
+    alert(e.response?.data?.msg || '删除失败')
+  }
+}
+</script>
+
+<style scoped>
+.page {
+  padding: 20px;
+}
+</style>

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -34,6 +34,7 @@
         <ActionBar
           @search="doSearch"
           @rest="doRest"
+          @craft="openCraft"
         />
 
         <SearchDialog
@@ -44,6 +45,12 @@
           @equip="equipFound"
           @replace="doReplace"
           @close="closeReplaceDialog"
+        />
+        <CraftDialog
+          v-model="craftVisible"
+          :bag-items="bagItems"
+          @confirm="doCraft"
+          @close="craftVisible=false"
         />
 
         <!-- 背包面板 -->
@@ -65,7 +72,8 @@ import ChatPanel from '../components/ChatPanel.vue'
 import ActionBar from '../components/ActionBar.vue'
 import AreaButtons from '../components/AreaButtons.vue'
 import SearchDialog from '../components/SearchDialog.vue'
-import { move, search, getStatus, getMapAreas, rest, pickItem, pickReplace, pickEquip, unequipItem, dropEquip, attack, lootCorpse, getChats, sendChat } from '../api'
+import CraftDialog from '../components/CraftDialog.vue'
+import { move, search, getStatus, getMapAreas, rest, pickItem, pickReplace, pickEquip, unequipItem, dropEquip, attack, lootCorpse, getChats, sendChat, craftItem } from '../api'
 import { playerId } from '../store/user'
 import { playerInfo as info } from '../store/player'
 import { mapAreas as places } from '../store/map'
@@ -77,6 +85,7 @@ const router = useRouter()
 
 const foundItem = ref(null)
 const replaceVisible = ref(false)
+const craftVisible = ref(false)
 let replaceItemId = null
 let restTimer = null
 let statusTimer = null
@@ -418,6 +427,22 @@ async function doLoot(slot) {
     checkDeath()
   } catch (e) {
     alert(e.response?.data?.msg || '拾取失败')
+  }
+}
+
+function openCraft() {
+  craftVisible.value = true
+}
+
+async function doCraft(indices) {
+  if (!playerId.value) return
+  try {
+    const { data } = await craftItem(playerId.value, indices)
+    info.value = data.player
+    addLog(data.message)
+    craftVisible.value = false
+  } catch (e) {
+    alert(e.response?.data?.msg || '合成失败')
   }
 }
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -19,6 +19,7 @@ import MapItemTable from '../pages/MapItemTable.vue';
 import NpcSpawnAdmin from '../pages/NpcSpawnAdmin.vue';
 import NpcsByArea from '../pages/NpcsByArea.vue';
 import NpcDirectory from '../pages/NpcDirectory.vue';
+import CraftRecipeAdmin from '../pages/CraftRecipeAdmin.vue';
 
 const routes = [
   { path: '/', name: 'Home', component: Home },
@@ -41,6 +42,7 @@ const routes = [
   { path: '/admin/npcspawns', name: 'NpcSpawnAdmin', component: NpcSpawnAdmin },
   { path: '/admin/npcs', name: 'NpcsByArea', component: NpcsByArea },
   { path: '/admin/npcdir', name: 'NpcDirectory', component: NpcDirectory },
+  { path: '/admin/craftrecipes', name: 'CraftRecipeAdmin', component: CraftRecipeAdmin },
 ];
 
 const router = createRouter({

--- a/mogoDB.md/craftrecipes.md
+++ b/mogoDB.md/craftrecipes.md
@@ -1,0 +1,32 @@
+# craftrecipes 集合
+
+记录物品合成配方。需要创建 `craftrecipes` 集合并初始化默认记录。
+
+```javascript
+use dts;
+db.craftrecipes.insertMany([
+  {
+    materials: ['面包', '矿泉水'],
+    materialHash: '面包|矿泉水',
+    result: { name: '简易便当', kind: 'HB', effect: 150, dur: '1', skill: '' }
+  },
+  {
+    materials: ['小刀', '磨刀石'],
+    materialHash: '小刀|磨刀石',
+    result: { name: '锋利的小刀', kind: 'WK', effect: 50, dur: '30', skill: '' }
+  },
+  {
+    materials: ['木棍', '铁钉', '胶带'],
+    materialHash: '木棍|铁钉|胶带',
+    result: { name: '钉棍', kind: 'WP', effect: 45, dur: '25', skill: '' }
+  }
+]);
+```
+
+为 `materialHash` 字段建立唯一索引：
+
+```javascript
+db.craftrecipes.createIndex({ materialHash: 1 }, { unique: true });
+```
+
+结构对应 `backend/src/models/CraftRecipe.js`。


### PR DESCRIPTION
## Summary
- implement `CraftRecipe` model and crafting service
- add `/craft` endpoint and controller
- initialize default crafting recipes
- document MongoDB setup for craftrecipes collection

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6889d3f06d9483229ca680473beab769