### PR TITLE
feat: unify admin table styles

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,6 +5,8 @@ import ElementPlus from 'element-plus';
 import 'element-plus/dist/index.css';
 import './style.css';
 import './styles/dark-theme.css';
+import './styles/game-tables.css';
+import './styles/admin-tables.css';
 
 const app = createApp(App);
 app.use(router);

--- a/frontend/src/pages/Admin.vue
+++ b/frontend/src/pages/Admin.vue
@@ -723,104 +723,6 @@ onMounted(() => {
   border-top: 1px solid #333;
   padding-top: 16px;
 }
-/* 后台表格样式 - 与游戏页面一致 */
-.admin-page :deep(.el-table) {
-  background: rgba(15, 25, 35, 0.85) !important;
-  border: 1px solid rgba(64, 224, 208, 0.2) !important;
-  border-radius: 6px !important;
-  backdrop-filter: blur(8px) !important;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3),
-              0 0 20px rgba(64, 224, 208, 0.05) !important;
-  color: #E8F4F8 !important;
-}
-
-.admin-page :deep(.el-table th.el-table__cell) {
-  background: rgba(5, 15, 25, 0.9) !important;
-  color: #40E0D0 !important;
-  border-bottom: 2px solid rgba(64, 224, 208, 0.3) !important;
-  border-right: 1px solid rgba(64, 224, 208, 0.1) !important;
-  font-weight: 600 !important;
-  font-size: 13px !important;
-  text-transform: uppercase !important;
-  letter-spacing: 0.5px !important;
-  padding: 12px 8px !important;
-  text-shadow: 0 0 5px rgba(64, 224, 208, 0.3) !important;
-}
-
-.admin-page :deep(.el-table td.el-table__cell) {
-  background: rgba(20, 30, 40, 0.7) !important;
-  color: #E8F4F8 !important;
-  border-bottom: 1px solid rgba(64, 224, 208, 0.1) !important;
-  border-right: 1px solid rgba(64, 224, 208, 0.05) !important;
-  padding: 10px 8px !important;
-  font-size: 13px !important;
-  line-height: 1.4 !important;
-}
-
-.admin-page :deep(.el-table tbody tr:hover > td.el-table__cell) {
-  background: rgba(25, 40, 55, 0.9) !important;
-  color: #FFFFFF !important;
-  box-shadow: inset 0 0 10px rgba(64, 224, 208, 0.1) !important;
-}
-
-.admin-page :deep(.el-table .el-table__row--striped td.el-table__cell) {
-  background: rgba(25, 35, 45, 0.7) !important;
-}
-
-.admin-page :deep(.el-table .el-button) {
-  background: rgba(64, 224, 208, 0.1) !important;
-  border: 1px solid rgba(64, 224, 208, 0.3) !important;
-  color: #40E0D0 !important;
-  font-size: 12px !important;
-  padding: 4px 8px !important;
-  border-radius: 3px !important;
-  transition: all 0.3s ease !important;
-}
-
-.admin-page :deep(.el-table .el-button:hover) {
-  background: rgba(64, 224, 208, 0.2) !important;
-  border-color: #40E0D0 !important;
-  color: #FFFFFF !important;
-  box-shadow: 0 0 8px rgba(64, 224, 208, 0.3) !important;
-}
-
-.admin-page :deep(.el-table .el-button--danger) {
-  background: rgba(255, 99, 71, 0.1) !important;
-  border-color: rgba(255, 99, 71, 0.3) !important;
-  color: #FF6347 !important;
-}
-
-.admin-page :deep(.el-table .el-button--danger:hover) {
-  background: rgba(255, 99, 71, 0.2) !important;
-  border-color: #FF6347 !important;
-  box-shadow: 0 0 8px rgba(255, 99, 71, 0.3) !important;
-}
-
-.admin-page :deep(.el-table .data-number) {
-  color: #87CEEB !important;
-  font-family: 'Consolas', 'Monaco', monospace !important;
-  font-weight: 500 !important;
-}
-
-.admin-page :deep(.el-table .data-status) {
-  color: #98FB98 !important;
-  font-weight: 500 !important;
-}
-
-.admin-page :deep(.el-table .data-warning) {
-  color: #FFB347 !important;
-  font-weight: 500 !important;
-}
-
-.admin-page :deep(.el-table__empty-block) {
-  background: transparent !important;
-  color: #888 !important;
-}
-
-.admin-page :deep(.el-table__empty-text) {
-  color: #888 !important;
-}
-
 /* 响应式设计 */
 @media (max-width: 768px) {
   .toolbar {
@@ -840,17 +742,6 @@ onMounted(() => {
   .toolbar-card,
   .table-card {
     margin: 0 16px 16px 16px;
-  }
-
-  .admin-page :deep(.el-table th.el-table__cell),
-  .admin-page :deep(.el-table td.el-table__cell) {
-    padding: 8px 6px !important;
-    font-size: 12px !important;
-  }
-
-  .admin-page :deep(.el-table .el-button) {
-    padding: 3px 6px !important;
-    font-size: 11px !important;
   }
 }
 </style>

--- a/frontend/src/pages/CraftRecipeAdmin.vue
+++ b/frontend/src/pages/CraftRecipeAdmin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h2>合成配方管理</h2>
     <el-button type="primary" size="small" @click="openCreate">新建</el-button>
     <el-table :data="recipes" style="margin-top:10px" @row-click="openEdit">

--- a/frontend/src/pages/ItemAdmin.vue
+++ b/frontend/src/pages/ItemAdmin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h2>物品管理</h2>
     <el-segmented v-model="currentKind" :options="kindOptions" style="margin-bottom:10px" />
     <el-button type="primary" size="small" @click="openCreate" style="margin-left:10px">新建</el-button>

--- a/frontend/src/pages/ItemCategoryAdmin.vue
+++ b/frontend/src/pages/ItemCategoryAdmin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h2>物品刷新管理
       <span v-if="area">- {{ areaName(area) }}</span>
     </h2>

--- a/frontend/src/pages/MapItemTable.vue
+++ b/frontend/src/pages/MapItemTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h3>刷新表 - {{ areaName(area) }}</h3>
     <el-button size="small" @click="goBack" style="margin-bottom:10px">返回</el-button>
     <el-tabs v-model="tab">

--- a/frontend/src/pages/MapItemsByArea.vue
+++ b/frontend/src/pages/MapItemsByArea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h3>地图物品 - {{ areaName(area) }}</h3>
     <el-button size="small" @click="goBack" style="margin-bottom:10px">返回</el-button>
     <el-table :data="items" style="width:100%" size="small">

--- a/frontend/src/pages/MapResourceAdmin.vue
+++ b/frontend/src/pages/MapResourceAdmin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h2>地图资源管理</h2>
     <el-button type="primary" size="small" style="margin-bottom:10px" @click="openCreateArea">新建地图</el-button>
     <el-button size="small" style="margin-left:10px" @click="goNpcDir">NPC目录</el-button>

--- a/frontend/src/pages/MapTrapTable.vue
+++ b/frontend/src/pages/MapTrapTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
 <h3>陷阱刷新表 - {{ areaName(area) }}</h3>
     <el-button size="small" @click="goBack" style="margin-bottom:10px">返回</el-button>
     <el-tabs v-model="tab">

--- a/frontend/src/pages/MapTrapsByArea.vue
+++ b/frontend/src/pages/MapTrapsByArea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h3>地图陷阱 - {{ areaName(area) }}</h3>
     <el-button size="small" @click="goBack" style="margin-bottom:10px">返回</el-button>
     <el-table :data="items" style="width:100%" size="small">

--- a/frontend/src/pages/NpcDirectory.vue
+++ b/frontend/src/pages/NpcDirectory.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h2>NPC目录</h2>
     <el-table :data="items" style="width:100%" size="small">
       <el-table-column prop="pid" label="ID" width="80" />

--- a/frontend/src/pages/NpcSpawnAdmin.vue
+++ b/frontend/src/pages/NpcSpawnAdmin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h2>NPC刷新机制管理</h2>
     <div style="margin-bottom:10px">
       <el-button v-if="areaId" size="small" @click="router.push(`/admin/mapresources?area=${areaId}`)">返回</el-button>

--- a/frontend/src/pages/NpcsByArea.vue
+++ b/frontend/src/pages/NpcsByArea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h3>NPC 列表 - {{ areaName(area) }}</h3>
     <el-button size="small" @click="goBack" style="margin-bottom:10px">返回</el-button>
     <el-table :data="items" style="width:100%" size="small">

--- a/frontend/src/pages/ShopItemsByArea.vue
+++ b/frontend/src/pages/ShopItemsByArea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page admin-page">
     <h3>商店物品 - {{ areaName(area) }}</h3>
     <el-button size="small" @click="goBack" style="margin-bottom:10px">返回</el-button>
     <el-table :data="items" style="width:100%" size="small">


### PR DESCRIPTION
## Summary
- use unified admin table CSS across backend pages
- mark admin subpages with `admin-page` class
- remove duplicated table styles from Admin.vue

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688af91337888322bbd0b9fd83698d3a