### PR TITLE
fix(参数): 补回敌人反击(点敌人会扣体力)

### DIFF
--- a/prototypes/parameters/index.html
+++ b/prototypes/parameters/index.html
@@ -342,6 +342,7 @@ function attack(c,el,ev){
     dmg=(a<=b)?Math.trunc(S.atk*(1-L4/2600)*0.5):Math.trunc(S.atk*0.25+R()*10-5); }
   if(dmg<1)dmg=1;
   c.hp-=dmg; handleCombo(); flash(el); floatText(el,'-'+dmg,'#c00',ev);
+  engaged=c; lastEng=performance.now();          // 交战:敌人会反击(见 frame())
   if(c.hp<=0){ defeat(c); }
   paint(c);
 }
@@ -350,7 +351,7 @@ function defeat(c){
   const g=Math.trunc(c.m/10), e=Math.trunc(c.m/15);
   addParam('GOLD',g); addParam('EXP',e);
   const keyCnt=Math.trunc(c.m/1000)%4+1; for(let i=0;i<keyCnt;i++)addParam('KEY',1);
-  S.e_comp++; msg(t('win')+' +'+g+'G','#f5c400');
+  S.e_comp++; if(engaged===c)engaged=null; msg(t('win')+' +'+g+'G','#f5c400');
   checkWin();
 }
 function work(c,el,ev){
@@ -461,11 +462,12 @@ function spendPoint(kind){ if(S.add_p<=0)return;
 // ============================================================================
 //  sim loop (setInterval — 不受失焦暂停;逐帧再生/连击/敌人回血)
 // ============================================================================
-let engaged=null, acc=0, last=performance.now();
+let engaged=null, lastEng=0, acc=0, last=performance.now();
 setInterval(()=>{
   if(S.over)return;
   const now=performance.now(); acc+=now-last; last=now; let steps=0;
-  while(acc>=DT && steps<8){ frame(); acc-=DT; steps++; }
+  while(acc>=DT && steps<8 && !S.over){ frame(); acc-=DT; steps++; }
+  if(engaged && now-lastEng>1500) engaged=null;   // 1.5s 不打这个敌人就脱离交战(停止挨打)
   renderStatus();
 },DT);
 function frame(){
@@ -474,6 +476,15 @@ function frame(){
   S.atk =Math.min(S.atk +0.03 +S.rpe*0.01, S.atk_max);
   S.def =Math.min(S.def +0.03 +S.rpe*0.01, S.def_max);
   if(S.combo_time>0){S.combo_time--; if(S.combo_time<=0)S.combo=0;}
+  // 交战中的敌人反击:每 15 帧(≈0.5s)打你一次(原版 setDamage 逻辑)
+  if(engaged && !engaged.done && !engaged.locked && (engaged.type==='enemy'||engaged.type==='boss')){
+    engaged.cnt=(engaged.cnt||0)+1;
+    if(engaged.cnt>=15){ engaged.cnt=0;
+      // 接触伤害:随敌人大小递增(小敌温和、大敌危险);格子偏方,故按宽度而非(宽+高)/2
+      const d=engaged.boss?Math.max(1,100-engaged.hp/4):(15+engaged.dw/4);
+      setDamage(d);
+    }
+  }
 }
 setInterval(()=>{ if(!S.over) repaintAll(); },140);
 

--- a/public/games/parameters.html
+++ b/public/games/parameters.html
@@ -342,6 +342,7 @@ function attack(c,el,ev){
     dmg=(a<=b)?Math.trunc(S.atk*(1-L4/2600)*0.5):Math.trunc(S.atk*0.25+R()*10-5); }
   if(dmg<1)dmg=1;
   c.hp-=dmg; handleCombo(); flash(el); floatText(el,'-'+dmg,'#c00',ev);
+  engaged=c; lastEng=performance.now();          // 交战:敌人会反击(见 frame())
   if(c.hp<=0){ defeat(c); }
   paint(c);
 }
@@ -350,7 +351,7 @@ function defeat(c){
   const g=Math.trunc(c.m/10), e=Math.trunc(c.m/15);
   addParam('GOLD',g); addParam('EXP',e);
   const keyCnt=Math.trunc(c.m/1000)%4+1; for(let i=0;i<keyCnt;i++)addParam('KEY',1);
-  S.e_comp++; msg(t('win')+' +'+g+'G','#f5c400');
+  S.e_comp++; if(engaged===c)engaged=null; msg(t('win')+' +'+g+'G','#f5c400');
   checkWin();
 }
 function work(c,el,ev){
@@ -461,11 +462,12 @@ function spendPoint(kind){ if(S.add_p<=0)return;
 // ============================================================================
 //  sim loop (setInterval — 不受失焦暂停;逐帧再生/连击/敌人回血)
 // ============================================================================
-let engaged=null, acc=0, last=performance.now();
+let engaged=null, lastEng=0, acc=0, last=performance.now();
 setInterval(()=>{
   if(S.over)return;
   const now=performance.now(); acc+=now-last; last=now; let steps=0;
-  while(acc>=DT && steps<8){ frame(); acc-=DT; steps++; }
+  while(acc>=DT && steps<8 && !S.over){ frame(); acc-=DT; steps++; }
+  if(engaged && now-lastEng>1500) engaged=null;   // 1.5s 不打这个敌人就脱离交战(停止挨打)
   renderStatus();
 },DT);
 function frame(){
@@ -474,6 +476,15 @@ function frame(){
   S.atk =Math.min(S.atk +0.03 +S.rpe*0.01, S.atk_max);
   S.def =Math.min(S.def +0.03 +S.rpe*0.01, S.def_max);
   if(S.combo_time>0){S.combo_time--; if(S.combo_time<=0)S.combo=0;}
+  // 交战中的敌人反击:每 15 帧(≈0.5s)打你一次(原版 setDamage 逻辑)
+  if(engaged && !engaged.done && !engaged.locked && (engaged.type==='enemy'||engaged.type==='boss')){
+    engaged.cnt=(engaged.cnt||0)+1;
+    if(engaged.cnt>=15){ engaged.cnt=0;
+      // 接触伤害:随敌人大小递增(小敌温和、大敌危险);格子偏方,故按宽度而非(宽+高)/2
+      const d=engaged.boss?Math.max(1,100-engaged.hp/4):(15+engaged.dw/4);
+      setDamage(d);
+    }
+  }
 }
 setInterval(()=>{ if(!S.over) repaintAll(); },140);
 


### PR DESCRIPTION
## 修复

重建 treemap 版时漏掉了敌人反击 —— `setDamage` 从未被调用,导致**体力永不下降、游戏无败北条件**(用户反馈:怎么点体力都不掉)。

- 点击敌人=交战:每 15 帧(≈0.5s)敌人反击一次(原版 cadence);**1.5s 不打该敌即脱离交战**,停止挨打(保留操作空间)。
- 接触伤害随敌人格宽递增(小敌温和、大敌危险);因 treemap 格子偏方,对原版 `20+(宽+高)/2` 缩放为 `15+宽/4`,避免过度惩罚。
- 受击仍走真值公式 `int(dmg*0.5*(1-def/300))`,死亡归零攻防。

🤖 Generated with [Claude Code](https://claude.com/claude-code)