### PR TITLE
fix(参数): 清一格最多升 1 级(去掉奖励面额级联)

### DIFF
--- a/prototypes/parameters/index.html
+++ b/prototypes/parameters/index.html
@@ -321,15 +321,9 @@ function addParam(kind,amount){
   } else if(kind==='KEY') S.key+=1;
   else if(kind==='KEY2') S.key2+=1;
 }
-// 把奖励按面额(1000/100/50/10/1)拆成多枚,逐枚 addParam —— 还原原版 setItem 的流式发放,
-// 于是每枚最多触发 1 级,升级(和点数)节流,不再"一坨大奖爆一堆点"。
-function award(kind,total){
-  total=Math.max(0,Math.round(total));
-  for(const d of [1000,100,50,10,1]){
-    let n=Math.floor(total/d); total-=n*d;
-    for(let i=0;i<n && i<300;i++) addParam(kind,d);
-  }
-}
+// 奖励发放:单次调用(EXP 走 addParam 的 if → 清一格最多升 1 级 = 最多 +3 点)。
+// (原先按面额拆成多枚会级联:大额 tile 把 exp 顶到远超 exp_max,后续每枚都触发一级 → 一格爆十几点。)
+function award(kind,total){ addParam(kind, Math.max(0,Math.round(total))); }
 function setDamage(dmg){
   const d0=Math.min(S.def,300);
   let d=Math.trunc(dmg*0.5*(1-d0/300)); if(d<5)d=Math.trunc(5+R()*10);

--- a/public/games/parameters.html
+++ b/public/games/parameters.html
@@ -321,15 +321,9 @@ function addParam(kind,amount){
   } else if(kind==='KEY') S.key+=1;
   else if(kind==='KEY2') S.key2+=1;
 }
-// 把奖励按面额(1000/100/50/10/1)拆成多枚,逐枚 addParam —— 还原原版 setItem 的流式发放,
-// 于是每枚最多触发 1 级,升级(和点数)节流,不再"一坨大奖爆一堆点"。
-function award(kind,total){
-  total=Math.max(0,Math.round(total));
-  for(const d of [1000,100,50,10,1]){
-    let n=Math.floor(total/d); total-=n*d;
-    for(let i=0;i<n && i<300;i++) addParam(kind,d);
-  }
-}
+// 奖励发放:单次调用(EXP 走 addParam 的 if → 清一格最多升 1 级 = 最多 +3 点)。
+// (原先按面额拆成多枚会级联:大额 tile 把 exp 顶到远超 exp_max,后续每枚都触发一级 → 一格爆十几点。)
+function award(kind,total){ addParam(kind, Math.max(0,Math.round(total))); }
 function setDamage(dmg){
   const d0=Math.min(S.def,300);
   let d=Math.trunc(dmg*0.5*(1-d0/300)); if(d<5)d=Math.trunc(5+R()*10);


### PR DESCRIPTION
承接上一个升级修复。上次用 `award()` 把奖励拆成 1000/100/50/10/1 多枚逐枚 `addParam`,但大额 tile 会把 `exp` 顶到远超 `exp_max`,后续每枚都触发一级 → **清一格爆十几点**。

改为 `award()` 单次 `addParam`(EXP 走 `if`,单次调用最多升 1 级):
- 清一格敌人 ≤ +3 点(1 级);任务完成 = 1 级(+3)+ 任务自带 `addAddP(1)` = +4
- 连清 6 敌 ≈ 18 点(每格 ~3),升级随游戏渐进,不再一格暴涨

jsdom 验证:最大可玩敌人一击清 = +3 点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)