### PR TITLE
fix(参数): 敌人反击随体型变化,不再所有敌人攻击一致

### DIFF
--- a/prototypes/parameters/index.html
+++ b/prototypes/parameters/index.html
@@ -398,7 +398,7 @@ function attack(c,el,ev){
   let d;
   if(c.boss) d=Math.max(1, 55 - hp0/9);           // 首领:越残血越狠
   else if(c.last) d=6 + (c.hpMax-hp0)/280 + R()*8;
-  else d=10 + c.dw/6;                              // 普通敌:随体型递增(每次点击都收到)
+  else d=6 + (c.dw+c.dh)/4;                        // 普通敌:随体型(宽+高)递增 —— 还原原版 20+(w+h)/2 的结构,缩放后每点一次都收到
   setDamage(d);
   if(!S.over && c.hp<=0){ defeat(c); }
   paint(c);

--- a/public/games/parameters.html
+++ b/public/games/parameters.html
@@ -398,7 +398,7 @@ function attack(c,el,ev){
   let d;
   if(c.boss) d=Math.max(1, 55 - hp0/9);           // 首领:越残血越狠
   else if(c.last) d=6 + (c.hpMax-hp0)/280 + R()*8;
-  else d=10 + c.dw/6;                              // 普通敌:随体型递增(每次点击都收到)
+  else d=6 + (c.dw+c.dh)/4;                        // 普通敌:随体型(宽+高)递增 —— 还原原版 20+(w+h)/2 的结构,缩放后每点一次都收到
   setDamage(d);
   if(!S.over && c.hp<=0){ defeat(c); }
   paint(c);


### PR DESCRIPTION
用户发现所有敌人攻击力几乎一致。核对字节码:原版接触伤害 = `setDamage(20+(宽+高)/2)`(`L3=mc.height, L4=mc.width, L5=20+(L3+L4)/2`),随大小强烈变化。

我之前把它 re-tune 成 `10+宽/6`:flat `10` 主导小敌 + 只用宽 / 除 6 → 17 个可玩敌里 8 个都是 7~8 伤害,且忽略高度(瘦高敌被当成同宽薄敌)。

改为 `6+(宽+高)/4`(还原原版结构,缩放后每点一次都收到):
- def10 下:小敌 ~9、瘦高敌 ~16、大敌 ~28(原来几乎全 7~8);瘦高敌不再被低估
- botplay 机器人仍从零通关整局(15/15 项含新增"反击随体型变化"检查全过)

🤖 Generated with [Claude Code](https://claude.com/claude-code)