### PR TITLE
fix(参数): 任务奖励按真值 /10 发放 —— 点最小房间不再爆 3 级/7 点

### DIFF
--- a/prototypes/parameters/index.html
+++ b/prototypes/parameters/index.html
@@ -415,15 +415,17 @@ function defeat(c){
   checkWin();
 }
 function work(c,el,ev){
-  if(c.complete_flg){ const g=Math.trunc(c.m/10+(R()*c.m)/100); award('GOLD',g);
+  // 原版 Mission.setItems 按 exp/10、gold/10 发放(真值),之前误发全额→小任务爆好几级
+  if(c.complete_flg){ const g=Math.round(Math.trunc(c.m/10+(R()*c.m)/100)/10); award('GOLD',g);
     floatText(el,'+'+g+'G','#f5c400',ev); flash(el); return; }
   if(S.act<c.cost){ msg(t('mNg'),'#888'); floatText(el,'ACT!','#888',ev); return; }
   S.act-=c.cost; c.hp+=10+R()*3; handleCombo(); flash(el);
   floatText(el,Math.min(100,Math.round(c.hp/c.hpMax*100))+'%','#39d0d8',ev);
   if(c.hp>c.hpMax){ c.hp=c.hpMax; c.complete_flg=true; c.done=true; S.m_comp++; addAddP(1);
     c.gold=Math.trunc(c.gold*1.5); c.exp=Math.trunc(c.exp*1.5);
-    award('GOLD',c.gold); award('EXP',c.exp);
-    msg(t('mComp')+' +'+c.gold+'G','#bc8cff'); checkWin(); }
+    const gg=Math.round(c.gold/10), ge=Math.round(c.exp/10);   // setItems 的 /10
+    award('GOLD',gg); award('EXP',ge);
+    msg(t('mComp')+' +'+gg+'G','#bc8cff'); checkWin(); }
   paint(c);
 }
 function buyItem(c,el,ev){

--- a/public/games/parameters.html
+++ b/public/games/parameters.html
@@ -415,15 +415,17 @@ function defeat(c){
   checkWin();
 }
 function work(c,el,ev){
-  if(c.complete_flg){ const g=Math.trunc(c.m/10+(R()*c.m)/100); award('GOLD',g);
+  // 原版 Mission.setItems 按 exp/10、gold/10 发放(真值),之前误发全额→小任务爆好几级
+  if(c.complete_flg){ const g=Math.round(Math.trunc(c.m/10+(R()*c.m)/100)/10); award('GOLD',g);
     floatText(el,'+'+g+'G','#f5c400',ev); flash(el); return; }
   if(S.act<c.cost){ msg(t('mNg'),'#888'); floatText(el,'ACT!','#888',ev); return; }
   S.act-=c.cost; c.hp+=10+R()*3; handleCombo(); flash(el);
   floatText(el,Math.min(100,Math.round(c.hp/c.hpMax*100))+'%','#39d0d8',ev);
   if(c.hp>c.hpMax){ c.hp=c.hpMax; c.complete_flg=true; c.done=true; S.m_comp++; addAddP(1);
     c.gold=Math.trunc(c.gold*1.5); c.exp=Math.trunc(c.exp*1.5);
-    award('GOLD',c.gold); award('EXP',c.exp);
-    msg(t('mComp')+' +'+c.gold+'G','#bc8cff'); checkWin(); }
+    const gg=Math.round(c.gold/10), ge=Math.round(c.exp/10);   // setItems 的 /10
+    award('GOLD',gg); award('EXP',ge);
+    msg(t('mComp')+' +'+gg+'G','#bc8cff'); checkWin(); }
   paint(c);
 }
 function buyItem(c,el,ev){


### PR DESCRIPTION
用户:「我点完了左上角最小的房间就升了 3 级给了 7 个技能点,绝对有问题」。

**根因**(核对原版字节码 `Mission/setItems` #104):原版发放任务奖励时按 `this.exp/10`、`this.gold/10` 拆 tile(`L3=(this.exp/10)`、`L3=(this.gold/10)` → 再拆成 100/50/10 面额 + 个位)。我之前误发**全额** `c.exp`/`c.gold`,于是一个 exp≈277 的小任务直接灌 277 经验 → 连升 2~3 级 + 任务固定 +1 点 = 7 点。

**改法(还原 /10)**:
- 完成任务:`award('GOLD', c.gold/10)`、`award('EXP', c.exp/10)`
- 复点已完成任务(M_OK2)补金也过 `setItems` → 同样再 /10
- 小任务净得经验 ≈28(< exp_max 100)→ 0 级,仅任务固定 +1 点

连带:任务金币随之 /10,主要金源改由「敌人掉落 + 宝箱 + 老虎机」承担(老虎机 +EV,是原版设计的刷金点)。botplay 机器人策略相应更新:金荒时刷老虎机补金 —— 仍从零**真实通关**(30/30 敌、57/57 任务、38 级、21 分钟)。

**验收 botplay 19/19 全过**(新增「最小任务 ≤1 级」回归项);浏览器加载 0 报错,棋盘渲染正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)