### PR TITLE
feat(参数): 任务经验改为逐击按进度发放 —— 升级平滑,不再"1升2一坨给7点"

### DIFF
--- a/prototypes/parameters/index.html
+++ b/prototypes/parameters/index.html
@@ -309,6 +309,9 @@ function initCell(c){
   } else if(c.type==='mission'){
     c.hpMax=Math.round(c.dw); c.hp=0;
     c.cost=c.m*0.01; c.gold=Math.trunc(c.m*0.03*(1+R())*2); c.exp=Math.trunc(c.m*0.1*(1+R())*2);
+    c.expReward=Math.round(Math.trunc(c.exp*1.5)/10);   // 任务总经验(原版完成 *1.5 再 setItems /10 的真值)—— 按进度逐击发放
+    c.goldReward=Math.round(Math.trunc(c.gold*1.5)/10); // 任务金币(完成时结算)
+    c.expGiven=0;                                       // 已按进度发出的经验(累计,收尾补齐尾数)
     S.total_m++;
   } else if(c.type==='weapon'){
     c.price=Math.max(10,Math.round(Math.trunc(c.m/10)+Math.pow(c.dh-30,2)+(c.dh-30)*45)); c.addP=Math.trunc(c.m/100)*0.45;
@@ -415,17 +418,20 @@ function defeat(c){
   checkWin();
 }
 function work(c,el,ev){
-  // 原版 Mission.setItems 按 exp/10、gold/10 发放(真值),之前误发全额→小任务爆好几级
+  // 完成后再点:只发金币(原版 M_OK2 分支)
   if(c.complete_flg){ const g=Math.round(Math.trunc(c.m/10+(R()*c.m)/100)/10); award('GOLD',g);
     floatText(el,'+'+g+'G','#f5c400',ev); flash(el); return; }
   if(S.act<c.cost){ msg(t('mNg'),'#888'); floatText(el,'ACT!','#888',ev); return; }
   S.act-=c.cost; c.hp+=10+R()*3; handleCombo(); flash(el);
-  floatText(el,Math.min(100,Math.round(c.hp/c.hpMax*100))+'%','#39d0d8',ev);
-  if(c.hp>c.hpMax){ c.hp=c.hpMax; c.complete_flg=true; c.done=true; S.m_comp++; addAddP(1);
-    c.gold=Math.trunc(c.gold*1.5); c.exp=Math.trunc(c.exp*1.5);
-    const gg=Math.round(c.gold/10), ge=Math.round(c.exp/10);   // setItems 的 /10
-    award('GOLD',gg); award('EXP',ge);
-    msg(t('mComp')+' +'+gg+'G','#bc8cff'); checkWin(); }
+  // 每次点击按"当前累计进度"发放对应经验(逐击滴入,而非完成时一坨)→ 经验平滑爬升、升级不再爆点
+  const prog=Math.min(1,c.hp/c.hpMax);
+  const target=Math.round(c.expReward*prog), dExp=Math.max(0,target-c.expGiven);
+  if(dExp>0){ c.expGiven+=dExp; award('EXP',dExp); }
+  floatText(el,Math.round(prog*100)+'%'+(dExp>0?' +'+dExp+'xp':''),'#39d0d8',ev);
+  if(c.hp>=c.hpMax){ c.hp=c.hpMax; c.complete_flg=true; c.done=true; S.m_comp++; addAddP(1);
+    const rest=Math.max(0,c.expReward-c.expGiven); if(rest>0){ c.expGiven+=rest; award('EXP',rest); }  // 补齐经验尾数
+    award('GOLD',c.goldReward);   // 金币完成时结算(+1 技能点=原版每完成一个任务固定给)
+    msg(t('mComp')+' +'+c.goldReward+'G','#bc8cff'); checkWin(); }
   paint(c);
 }
 function buyItem(c,el,ev){

--- a/public/games/parameters.html
+++ b/public/games/parameters.html
@@ -309,6 +309,9 @@ function initCell(c){
   } else if(c.type==='mission'){
     c.hpMax=Math.round(c.dw); c.hp=0;
     c.cost=c.m*0.01; c.gold=Math.trunc(c.m*0.03*(1+R())*2); c.exp=Math.trunc(c.m*0.1*(1+R())*2);
+    c.expReward=Math.round(Math.trunc(c.exp*1.5)/10);   // 任务总经验(原版完成 *1.5 再 setItems /10 的真值)—— 按进度逐击发放
+    c.goldReward=Math.round(Math.trunc(c.gold*1.5)/10); // 任务金币(完成时结算)
+    c.expGiven=0;                                       // 已按进度发出的经验(累计,收尾补齐尾数)
     S.total_m++;
   } else if(c.type==='weapon'){
     c.price=Math.max(10,Math.round(Math.trunc(c.m/10)+Math.pow(c.dh-30,2)+(c.dh-30)*45)); c.addP=Math.trunc(c.m/100)*0.45;
@@ -415,17 +418,20 @@ function defeat(c){
   checkWin();
 }
 function work(c,el,ev){
-  // 原版 Mission.setItems 按 exp/10、gold/10 发放(真值),之前误发全额→小任务爆好几级
+  // 完成后再点:只发金币(原版 M_OK2 分支)
   if(c.complete_flg){ const g=Math.round(Math.trunc(c.m/10+(R()*c.m)/100)/10); award('GOLD',g);
     floatText(el,'+'+g+'G','#f5c400',ev); flash(el); return; }
   if(S.act<c.cost){ msg(t('mNg'),'#888'); floatText(el,'ACT!','#888',ev); return; }
   S.act-=c.cost; c.hp+=10+R()*3; handleCombo(); flash(el);
-  floatText(el,Math.min(100,Math.round(c.hp/c.hpMax*100))+'%','#39d0d8',ev);
-  if(c.hp>c.hpMax){ c.hp=c.hpMax; c.complete_flg=true; c.done=true; S.m_comp++; addAddP(1);
-    c.gold=Math.trunc(c.gold*1.5); c.exp=Math.trunc(c.exp*1.5);
-    const gg=Math.round(c.gold/10), ge=Math.round(c.exp/10);   // setItems 的 /10
-    award('GOLD',gg); award('EXP',ge);
-    msg(t('mComp')+' +'+gg+'G','#bc8cff'); checkWin(); }
+  // 每次点击按"当前累计进度"发放对应经验(逐击滴入,而非完成时一坨)→ 经验平滑爬升、升级不再爆点
+  const prog=Math.min(1,c.hp/c.hpMax);
+  const target=Math.round(c.expReward*prog), dExp=Math.max(0,target-c.expGiven);
+  if(dExp>0){ c.expGiven+=dExp; award('EXP',dExp); }
+  floatText(el,Math.round(prog*100)+'%'+(dExp>0?' +'+dExp+'xp':''),'#39d0d8',ev);
+  if(c.hp>=c.hpMax){ c.hp=c.hpMax; c.complete_flg=true; c.done=true; S.m_comp++; addAddP(1);
+    const rest=Math.max(0,c.expReward-c.expGiven); if(rest>0){ c.expGiven+=rest; award('EXP',rest); }  // 补齐经验尾数
+    award('GOLD',c.goldReward);   // 金币完成时结算(+1 技能点=原版每完成一个任务固定给)
+    msg(t('mComp')+' +'+c.goldReward+'G','#bc8cff'); checkWin(); }
   paint(c);
 }
 function buyItem(c,el,ev){


### PR DESCRIPTION
用户:等级 0→1 只给 1 点(对),但 1→2 又一坨给了 **7 点**;要求「改为每次点击给与对应进度的经验值」。

**根因**(核对原版 `Mission/onDown` 字节码):原版完成任务时 `exp*=1.5`、`gold*=1.5`、`addAddP(1)`(每完成一个任务固定 +1 点),再 `setItems()` 把经验/金币拆成飞行 tile(/10)。我之前把整份经验在**完成那一下一坨入账** → 攒够跨过 `exp_max` 时一次性跳级、叠加沿途每个任务的固定 +1,看起来就是「1升2 突然给 7 点」(其实是 4 任务×1 + 升级×3)。

**改法(逐击按进度发经验):**
- `initCell` 预算 `c.expReward = round(trunc(exp*1.5)/10)`(总量 = 原版 /10 真值)、`c.goldReward`、`c.expGiven=0`
- `work()` 每次点击按「当前累计进度 `prog=hp/hpMax`」发对应经验:`dExp = round(expReward*prog) - expGiven`,逐击滴入;完成补齐尾数,总量恰 = `expReward`
- 完成时仍 `addAddP(1)` + 结算金币(还原原版「每任务固定 +1 点」)

**效果:** 经验条随每次点击平滑上涨、升级落在自己那一击(每帧最多升 1 级),不再一坨跳级爆点。点数账目完全可解释 = **任务数×1 + 升级数×3**,无隐藏加点。

**验收:**
- botplay **23/23**(新增 4 项:逐击入账 / 总量=expReward / 单帧≤1级 / 点数可解释)
- 浏览器实测最小任务(reward 22):点击 44%→+10、83%→+8、100%→+4,合计 22,**0 级 +1 点**,0 报错
- 机器人仍从零真实通关(30/30 敌、57/57 任务)

🤖 Generated with [Claude Code](https://claude.com/claude-code)