### PR TITLE
fix(参数): 敌人反击差距做实 —— 去随机地板,里首领成最强反击

### DIFF
--- a/prototypes/parameters/index.html
+++ b/prototypes/parameters/index.html
@@ -350,8 +350,8 @@ function addParam(kind,amount){
 function award(kind,total){ total=Math.max(0,Math.round(total));
   if(kind==='EXP') S.pendingExp+=total; else addParam(kind,total); }
 function setDamage(dmg){
-  const d0=Math.min(S.def,300);
-  let d=Math.trunc(dmg*0.5*(1-d0/300)); if(d<5)d=Math.trunc(5+R()*10);
+  const d0=Math.min(S.def,285);
+  let d=Math.round(dmg*(0.6-0.5*d0/300)); if(d<1)d=1;   // 防御减免最多 ~72%(保留一成半)——去掉"随机5~14地板",它把大小敌人的反击都压成同一个随机数→"感觉不出区别"
   S.life-=d; msg(t('taken',d),'#ff4444');
   if(S.life<0){S.life=0;S.atk=0;S.def=0;gameOver();}
 }
@@ -402,9 +402,9 @@ function attack(c,el,ev){
   // 敌人反击:玩家每次点击都收到一次(含击杀那一下 → 清怪也要付出体力)
   const hp0=Math.max(0,c.hp);
   let d;
-  if(c.boss) d=Math.max(1, 55 - hp0/9);           // 首领:越残血越狠
-  else if(c.last) d=6 + (c.hpMax-hp0)/280 + R()*8;
-  else d=6 + (c.dw+c.dh)/4;                        // 普通敌:随体型(宽+高)递增 —— 还原原版 20+(w+h)/2 的结构,缩放后每点一次都收到
+  if(c.boss)      d = 45 + (c.hpMax-hp0)/5;        // 首领(240血):45→93,越残血越狠
+  else if(c.last) d = 150 + (c.hpMax-hp0)/160;     // 里首领(9999血):终盘最强,随进度 150→212(不再像小怪一样只有个位数,但可持久战)
+  else            d = 8 + (c.dw+c.dh)/4;           // 普通敌:随体型(宽+高)——小敌轻、大敌重,差距明显(原版 20+(w+h)/2 的结构)
   setDamage(d);
   if(!S.over && c.hp<=0){ defeat(c); }
   paint(c);

--- a/public/games/parameters.html
+++ b/public/games/parameters.html
@@ -350,8 +350,8 @@ function addParam(kind,amount){
 function award(kind,total){ total=Math.max(0,Math.round(total));
   if(kind==='EXP') S.pendingExp+=total; else addParam(kind,total); }
 function setDamage(dmg){
-  const d0=Math.min(S.def,300);
-  let d=Math.trunc(dmg*0.5*(1-d0/300)); if(d<5)d=Math.trunc(5+R()*10);
+  const d0=Math.min(S.def,285);
+  let d=Math.round(dmg*(0.6-0.5*d0/300)); if(d<1)d=1;   // 防御减免最多 ~72%(保留一成半)——去掉"随机5~14地板",它把大小敌人的反击都压成同一个随机数→"感觉不出区别"
   S.life-=d; msg(t('taken',d),'#ff4444');
   if(S.life<0){S.life=0;S.atk=0;S.def=0;gameOver();}
 }
@@ -402,9 +402,9 @@ function attack(c,el,ev){
   // 敌人反击:玩家每次点击都收到一次(含击杀那一下 → 清怪也要付出体力)
   const hp0=Math.max(0,c.hp);
   let d;
-  if(c.boss) d=Math.max(1, 55 - hp0/9);           // 首领:越残血越狠
-  else if(c.last) d=6 + (c.hpMax-hp0)/280 + R()*8;
-  else d=6 + (c.dw+c.dh)/4;                        // 普通敌:随体型(宽+高)递增 —— 还原原版 20+(w+h)/2 的结构,缩放后每点一次都收到
+  if(c.boss)      d = 45 + (c.hpMax-hp0)/5;        // 首领(240血):45→93,越残血越狠
+  else if(c.last) d = 150 + (c.hpMax-hp0)/160;     // 里首领(9999血):终盘最强,随进度 150→212(不再像小怪一样只有个位数,但可持久战)
+  else            d = 8 + (c.dw+c.dh)/4;           // 普通敌:随体型(宽+高)——小敌轻、大敌重,差距明显(原版 20+(w+h)/2 的结构)
   setDamage(d);
   if(!S.over && c.hp<=0){ defeat(c); }
   paint(c);


### PR DESCRIPTION
用户:「敌人的攻击力好像没有区别,我打最底下的那个大格都感觉不太出来区别」。

**两个叠加根因:**
1. `setDamage` 有个「随机 5~14 地板」(`d<5 → 5+rnd*10`):防御一高(打到底部大格时通常已堆防御),几乎所有敌人减伤后反击都跌破 5,被统一替换成**同一个随机数** → 大小敌人反击全变 5~14,「感觉不出区别」。
2. 里首领反击 `6+(9999-hp0)/280`:因 `hpMax=9999`,满血时缩放项≈0,起手只有 **6~14** → 最大的格子却像小怪,还被地板抹平。

**改法:**
- `setDamage` 去随机地板 → 线性减伤 `round(dmg*(0.6-0.5*def/300))`(减伤最多 ~72%,保留一成半),floor=1 → 体型差距一路透传到高防御后期
- 里首领 `150+(9999-hp0)/160`(150→212 raw),终盘最强且可持久战;首领 `45+(240-hp0)/5`;普通敌 `8+(宽+高)/4`

**实测掉血(浏览器,按防御 50/150/222):**

| 敌 | 尺寸 | def50 | def150 | def222 |
|---|---|---|---|---|
| 小敌 | 40×14 | 11 | 8 | 5 |
| 中敌 | 94×44 | 22 | 15 | 10 |
| 大敌 | 412×52 | 64 | 43 | 29 |
| 首领 | 288×48 | 23 | 16 | 10 |
| **里首领满血** | 752×72 | **78** | **53** | **35** |
| **里首领半血** | — | **94** | **63** | **42** |

里首领稳居最强,体型差距清晰可感。

**验收:** botplay **24/24**(反击回归项改为「真实代码路径量实际掉血 + 高防御下仍区分 + 里首领最强」;并修好机器人 `counterEst` 用旧公式误判送死的问题);机器人仍从零真实通关(30/30、57/57)。0 报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)